### PR TITLE
feat: 초기 Security 설정 추가

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/config/SecurityConfig.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/config/SecurityConfig.java
@@ -1,0 +1,44 @@
+package com.silsonfit.silsonfit_api.config;
+
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.web.SecurityFilterChain;
+
+@Configuration
+public class SecurityConfig {
+
+    @Bean
+    public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
+        http
+                // 초기 개발 단계에서는 CSRF 비활성화
+                .csrf(AbstractHttpConfigurer::disable)
+
+                // H2 콘솔 사용을 위해 sameOrigin 허용
+                .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
+
+                // form login / http basic 비활성화
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+
+                // 요청 허용 정책
+                .authorizeHttpRequests(auth -> auth
+                        .requestMatchers(
+                                "/",
+                                "/error",
+                                "/h2-console/**",
+                                "/swagger-ui/**",
+                                "/swagger-ui.html",
+                                "/v3/api-docs/**",
+                                "/actuator/health",
+                                "/actuator/info"
+                        ).permitAll()
+                        .anyRequest().permitAll()
+                );
+
+        return http.build();
+    }
+}


### PR DESCRIPTION
<!-- PR의 타입은 Label을 통해 나타내주세요. -->

### 💻 작업 내용
<!-- 진행한 작업 내용에 대해 작성해주세요. -->
- Spring Security 기본 설정 추가
- 개발 단계에서 API 테스트가 가능하도록 모든 요청 허용 설정 적용
- Swagger, H2 콘솔, actuator 일부 엔드포인트 접근 허용
- CSRF, formLogin, httpBasic 비활성화

### 📝 메모
<!-- PR 관련 전달사항이 있다면 이곳에 작성해주세요. -->
- 현재는 개발 편의를 위해 모든 요청을 허용하는 초기 설정 상태입니다.
- 추후 인증 방식이 확정되면 permitAll 범위를 축소하고 인증/인가 정책을 별도 PR로 반영할 예정입니다.
- 디렉토리 관련 토의가 없었어서 우선 config 만들고 넣었는데 어떻게 하면 좋을 지 의견있으면 리뷰 남겨주세요!

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
closed 
