### PR TITLE
feat: 약관분석이력 도메인 엔티티, Repository, DTO 구현(#11)

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/dto/AnalysisResultDTO.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/dto/AnalysisResultDTO.java
@@ -1,0 +1,44 @@
+package com.silsonfit.silsonfit_api.domain.analysis.dto;
+
+import java.util.List;
+
+/**
+ * AI API 의 응답을 받을 수 있는 DTO
+ */
+public record AnalysisResultDTO(
+        Metadata metadata,
+        SummaryContent content
+) {
+
+    /**
+     * PDF 표지 / 개요 등에서 추출한 보험 기본 정보 ( 보험이 없다면 이 정보를 사용함 )
+     */
+    public record Metadata(
+            String companyName,         // 보험사
+            String productName,         // 약관 이름
+            String contractType,        // 계약 유형
+            String generation,          // 세대
+            String coverageStructure,   // 보장 구조
+            String cautionPoint         // 주의 포인트
+    ) {}
+
+    /**
+     * 보험 상세 분석 결과
+     */
+    public record SummaryContent(
+            List<String> coreSummary,           // AI 핵심 요약
+            CoverageDetails coverageDetails,    // 보장 구조
+            List<String> coverageScope,         // 보장 범위
+            List<String> limitations,           // 제한 조건
+            List<String> renewalTerms,          // 갱신, 재가입
+            List<String> claimMethod,           // 청구 방법
+            List<String> cancellationAndRefund  // 해지, 환급
+    ) {}
+
+    public record CoverageDetails(
+            List<String> basicCoverages,    // 기본 보장
+            List<String> specialCoverages,  // 추가 보장 (특약 가입 시)
+            List<String> exclusions         // 보장되지 않는 항목
+    ) {
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/entity/AnalysisHistory.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/entity/AnalysisHistory.java
@@ -1,0 +1,88 @@
+package com.silsonfit.silsonfit_api.domain.analysis.entity;
+
+import com.silsonfit.silsonfit_api.domain.analysis.dto.AnalysisResultDTO;
+import com.silsonfit.silsonfit_api.global.common.BaseCreatedTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.type.SqlTypes;
+
+/**
+ * AI의 약관 분석 결과 이력을 저장하는 엔티티
+ */
+@Entity
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AnalysisHistory extends BaseCreatedTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "analysis_history_id")
+    private Long id;
+
+    // 유저 id만 필요하기 때문에 객체 참조 x
+    @Column(name = "user_id")
+    private Long userId;
+
+    // 1. 파일 정보
+    @Column(name = "original_file_name", nullable = false)
+    private String originalFileName; // 삼성화재_약관.pdf
+
+    @Column(name = "pdf_file_url", nullable = false, length = 1000)
+    private String pdfFileUrl; // S3 스토리지 URL
+
+    // 2. 보험 관련 정보 스냅샷
+    @Column(name = "company_name")
+    private String companyName; // 보험사
+
+    @Column(name = "product_name")
+    private String productName; // 약관 이름
+
+    @Column(name = "contract_type")
+    private String contractType; // 계약 유형
+
+    @Column(name = "generation")
+    private String generation; // 보험 세대
+
+    @Column(name = "coverage_structure")
+    private String coverageStructure; // 보장 구조
+
+    @Column(name = "caution_point")
+    private String cautionPoint; // 주의 포인트
+
+    // 3. AI 분석 결과
+    @JdbcTypeCode(SqlTypes.JSON)
+    @Column(name = "ai_summary", columnDefinition = "jsonb")
+    private AnalysisResultDTO aiSummary;
+
+    // 4. 추가 기능
+    @Column(name = "is_favorite", nullable = false)
+    @Builder.Default
+    private Boolean isFavorite = false; // 즐겨찾기
+
+    // 생성자 - 정적 팩토리 메서드 패턴 + 빌더 사용
+    public static AnalysisHistory create(Long userId, String originalFileName, String pdfFileUrl,
+                                         String companyName, String productName, String contractType,
+                                         String generation, String coverageStructure, String cautionPoint,
+                                         AnalysisResultDTO aiSummary) {
+        return AnalysisHistory.builder()
+                .userId(userId)
+                .originalFileName(originalFileName)
+                .pdfFileUrl(pdfFileUrl)
+                .companyName(companyName)
+                .productName(productName)
+                .contractType(contractType)
+                .generation(generation)
+                .coverageStructure(coverageStructure)
+                .cautionPoint(cautionPoint)
+                .aiSummary(aiSummary)
+                .build();
+    }
+
+    // 즐겨찾기 ON / OFF
+    public void toggleFavorite() {
+        this.isFavorite = !this.isFavorite;
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/entity/AnalysisHistory.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/entity/AnalysisHistory.java
@@ -1,6 +1,6 @@
 package com.silsonfit.silsonfit_api.domain.analysis.entity;
 
-import com.silsonfit.silsonfit_api.domain.analysis.dto.AnalysisResultDTO;
+import com.silsonfit.silsonfit_api.domain.analysis.vo.AnalysisResult;
 import com.silsonfit.silsonfit_api.global.common.BaseCreatedTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
@@ -55,7 +55,7 @@ public class AnalysisHistory extends BaseCreatedTimeEntity {
     // 3. AI 분석 결과
     @JdbcTypeCode(SqlTypes.JSON)
     @Column(name = "ai_summary", columnDefinition = "jsonb")
-    private AnalysisResultDTO aiSummary;
+    private AnalysisResult aiSummary;
 
     // 4. 추가 기능
     @Column(name = "is_favorite", nullable = false)
@@ -66,7 +66,7 @@ public class AnalysisHistory extends BaseCreatedTimeEntity {
     public static AnalysisHistory create(Long userId, String originalFileName, String pdfFileUrl,
                                          String companyName, String productName, String contractType,
                                          String generation, String coverageStructure, String cautionPoint,
-                                         AnalysisResultDTO aiSummary) {
+                                         AnalysisResult aiSummary) {
         return AnalysisHistory.builder()
                 .userId(userId)
                 .originalFileName(originalFileName)

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/entity/AnalysisHistory.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/entity/AnalysisHistory.java
@@ -34,22 +34,22 @@ public class AnalysisHistory extends BaseCreatedTimeEntity {
     private String pdfFileUrl; // S3 스토리지 URL
 
     // 2. 보험 관련 정보 스냅샷
-    @Column(name = "company_name")
+    @Column(name = "company_name", nullable = false)
     private String companyName; // 보험사
 
-    @Column(name = "product_name")
+    @Column(name = "product_name", nullable = false)
     private String productName; // 약관 이름
 
-    @Column(name = "contract_type")
+    @Column(name = "contract_type", nullable = false)
     private String contractType; // 계약 유형
 
-    @Column(name = "generation")
+    @Column(name = "generation", nullable = false)
     private String generation; // 보험 세대
 
-    @Column(name = "coverage_structure")
+    @Column(name = "coverage_structure", nullable = false)
     private String coverageStructure; // 보장 구조
 
-    @Column(name = "caution_point")
+    @Column(name = "caution_point", nullable = false)
     private String cautionPoint; // 주의 포인트
 
     // 3. AI 분석 결과

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/repository/AnalysisHistoryRepository.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/repository/AnalysisHistoryRepository.java
@@ -21,5 +21,5 @@ public interface AnalysisHistoryRepository extends JpaRepository<AnalysisHistory
             where a.userId = :userId
             order by a.isFavorite desc, a.createdAt desc
             """)
-    Page<AnalysisHistory> findHistoriesByUserId(@Param("user_id") Long userId, Pageable pageable);
+    Page<AnalysisHistory> findHistoriesByUserId(@Param("userId") Long userId, Pageable pageable);
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/repository/AnalysisHistoryRepository.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/repository/AnalysisHistoryRepository.java
@@ -1,0 +1,25 @@
+package com.silsonfit.silsonfit_api.domain.analysis.repository;
+
+import com.silsonfit.silsonfit_api.domain.analysis.entity.AnalysisHistory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+public interface AnalysisHistoryRepository extends JpaRepository<AnalysisHistory, Long> {
+
+    /**
+     * 특정 유저의 분석 이력 목록을 조회 (즐겨찾기 우선, 최신순 정렬)
+     *
+     * @param userId    조회할 유저 ID
+     * @param pageable  페이징 정보
+     * @return          분석 이력 페이징 결과
+     */
+    @Query("""
+            select a from AnalysisHistory a
+            where a.userId = :userId
+            order by a.isFavorite desc, a.createdAt desc
+            """)
+    Page<AnalysisHistory> findHistoriesByUserId(@Param("user_id") Long userId, Pageable pageable);
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/vo/AnalysisResult.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/vo/AnalysisResult.java
@@ -1,11 +1,11 @@
-package com.silsonfit.silsonfit_api.domain.analysis.dto;
+package com.silsonfit.silsonfit_api.domain.analysis.vo;
 
 import java.util.List;
 
 /**
  * AI API 의 응답을 받을 수 있는 DTO
  */
-public record AnalysisResultDTO(
+public record AnalysisResult(
         Metadata metadata,
         SummaryContent content
 ) {


### PR DESCRIPTION
<!-- PR의 타입은 Label을 통해 나타내주세요. -->

### 💻 작업 내용
<!-- 진행한 작업 내용에 대해 작성해주세요. -->
- AI 분석 결과를 받기 위한 AnalysisResult VO 객체 생성
- AnalysisHistory 엔티티 생성
- AnalysisHistoryRepository 생성  

### ✨ 리뷰 포인트
<!-- (ex) query 가 너무 복잡한 것 같은데 이 위주로 봐주세요. -->

### 📝 메모
<!-- PR 관련 전달사항이 있다면 이곳에 작성해주세요. -->
- AnalysisResult는 원래 DTO로 생성했었는데 엔티티가 DTO를 필드로 가지는게 어색하다고 판단되어 vo(value object) 디렉토리로 옮긴후 클래스명 변경, record 타입으로 생성하여 많은 양의 필드들을 간결하게 정의함.
- AnalysisHistoryRepository에서 특정 유저의 분석 이력 목록을 조회하는 기능 추가. (즐겨찾기 우선, 최신순 정렬) 
- AnalysisHistory 엔티티의 생성자는 정적 팩토리 메서드 패턴 + 빌더를 조합하여 외부에서 엔티티를 생성하는 것을 막고 정적 팩토리 메서드를 통해 항상 같은 상태로 생성되도록 함.

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
closed #11 
