### PR TITLE
feat: 카카오 로그인 및 JWT 인증 기능 구현 (#12)

### DIFF
--- a/silsonfit-api/build.gradle
+++ b/silsonfit-api/build.gradle
@@ -27,6 +27,11 @@ dependencies {
 	// 인증 / 인가 처리
 	implementation 'org.springframework.boot:spring-boot-starter-security'
 
+	// JWT 토큰 생성 / 파싱 / 검증
+	implementation 'io.jsonwebtoken:jjwt-api:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-impl:0.12.6'
+	runtimeOnly 'io.jsonwebtoken:jjwt-jackson:0.12.6'
+
 	// DTO 요청값 검증 (@Valid, @NotNull 등)
 	implementation 'org.springframework.boot:spring-boot-starter-validation'
 

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/client/KakaoClient.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/client/KakaoClient.java
@@ -1,0 +1,111 @@
+package com.silsonfit.silsonfit_api.domain.auth.client;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatusCode;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+
+/**
+ * 카카오 API와의 통신을 담당하는 Client
+ *
+ * 카카오 Access Token을 이용해 사용자 정보를 조회한다.
+ * 토큰이 유효하지 않으면 INVALID_KAKAO_TOKEN,
+ * 그 외 통신/응답 오류는 KAKAO_SERVER_ERROR로 변환한다.
+ */
+@Component
+public class KakaoClient {
+
+    private final String kakaoUserInfoUri;
+    private final RestClient restClient;
+
+    public KakaoClient(
+            @Value("${kakao.user-info-uri}") String kakaoUserInfoUri,
+            RestClient.Builder restClientBuilder
+    ) {
+        this.kakaoUserInfoUri = kakaoUserInfoUri;
+        this.restClient = restClientBuilder.build();
+    }
+
+    /**
+     * 카카오 Access Token으로 사용자 정보를 조회한다.
+     *
+     * @param kakaoAccessToken 카카오 Access Token
+     * @return 카카오 사용자 정보
+     * @throws BusinessException 토큰 무효(401) 또는 카카오 서버 오류 시
+     */
+    public KakaoUserInfo getUserInfo(String kakaoAccessToken) {
+        KakaoResponse response;
+        try {
+            response = restClient.get()
+                    .uri(kakaoUserInfoUri)
+                    .header(HttpHeaders.AUTHORIZATION, "Bearer " + kakaoAccessToken)
+                    .retrieve()
+                    .onStatus(status -> status.value() == 401, (req, res) -> {
+                        throw new BusinessException(ErrorCode.INVALID_KAKAO_TOKEN);
+                    })
+                    .onStatus(HttpStatusCode::isError, (req, res) -> {
+                        throw new BusinessException(ErrorCode.KAKAO_SERVER_ERROR);
+                    })
+                    .body(KakaoResponse.class);
+        } catch (BusinessException e) {
+            // onStatus에서 던진 예외는 그대로 전파
+            throw e;
+        } catch (Exception e) {
+            // 네트워크 오류, 응답 파싱 실패 등
+            throw new BusinessException(ErrorCode.KAKAO_SERVER_ERROR);
+        }
+
+        if (response == null) {
+            throw new BusinessException(ErrorCode.KAKAO_SERVER_ERROR);
+        }
+
+        // 카카오 응답은 선택 동의 항목이 null일 수 있어 방어적으로 꺼낸다
+        KakaoAccount account = response.kakaoAccount();
+        Profile profile = (account != null) ? account.profile() : null;
+
+        return new KakaoUserInfo(
+                response.id(),
+                (profile != null) ? profile.nickname() : null,
+                (account != null) ? account.email() : null,
+                (profile != null) ? profile.profileImageUrl() : null
+        );
+    }
+
+    /**
+     * KakaoClient가 외부로 반환하는 사용자 정보
+     *
+     * name 필드는 카카오의 profile.nickname 값을 매핑한 것이다.
+     * 서비스 도메인(User 엔티티)의 name과 의미를 일치시키기 위해 외부 명칭은 name으로 통일한다.
+     */
+    public record KakaoUserInfo(
+            Long id,
+            String name,
+            String email,
+            String profileImageUrl
+    ) {
+    }
+
+    // ── 카카오 API 응답 매핑용 내부 record ──
+
+    private record KakaoResponse(
+            Long id,
+            @JsonProperty("kakao_account") KakaoAccount kakaoAccount
+    ) {
+    }
+
+    private record KakaoAccount(
+            String email,
+            Profile profile
+    ) {
+    }
+
+    private record Profile(
+            String nickname,
+            @JsonProperty("profile_image_url") String profileImageUrl
+    ) {
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/client/KakaoClient.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/client/KakaoClient.java
@@ -10,11 +10,10 @@ import org.springframework.stereotype.Component;
 import org.springframework.web.client.RestClient;
 
 /**
- * 카카오 API와의 통신을 담당하는 Client
+ * 카카오 API 통신 Client
  *
- * 카카오 Access Token을 이용해 사용자 정보를 조회한다.
- * 토큰이 유효하지 않으면 INVALID_KAKAO_TOKEN,
- * 그 외 통신/응답 오류는 KAKAO_SERVER_ERROR로 변환한다.
+ * 카카오 Access Token으로 사용자 정보 조회
+ * 토큰 무효 시 INVALID_KAKAO_TOKEN, 그 외 오류는 KAKAO_SERVER_ERROR로 변환
  */
 @Component
 public class KakaoClient {
@@ -31,11 +30,7 @@ public class KakaoClient {
     }
 
     /**
-     * 카카오 Access Token으로 사용자 정보를 조회한다.
-     *
-     * @param kakaoAccessToken 카카오 Access Token
-     * @return 카카오 사용자 정보
-     * @throws BusinessException 토큰 무효(401) 또는 카카오 서버 오류 시
+     * 카카오 Access Token으로 사용자 정보 조회
      */
     public KakaoUserInfo getUserInfo(String kakaoAccessToken) {
         KakaoResponse response;
@@ -63,7 +58,7 @@ public class KakaoClient {
             throw new BusinessException(ErrorCode.KAKAO_SERVER_ERROR);
         }
 
-        // 카카오 응답은 선택 동의 항목이 null일 수 있어 방어적으로 꺼낸다
+        // 카카오 선택 동의 항목은 null일 수 있으므로 null 체크 후 추출
         KakaoAccount account = response.kakaoAccount();
         Profile profile = (account != null) ? account.profile() : null;
 
@@ -76,10 +71,10 @@ public class KakaoClient {
     }
 
     /**
-     * KakaoClient가 외부로 반환하는 사용자 정보
+     * KakaoClient 외부 반환 사용자 정보
      *
-     * name 필드는 카카오의 profile.nickname 값을 매핑한 것이다.
-     * 서비스 도메인(User 엔티티)의 name과 의미를 일치시키기 위해 외부 명칭은 name으로 통일한다.
+     * name 필드는 카카오 profile.nickname 매핑
+     * User 엔티티의 name과 통일
      */
     public record KakaoUserInfo(
             Long id,

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/controller/AuthController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/controller/AuthController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
  * 카카오 로그인과 토큰 재발급 제공
  */
 @RestController
-@RequestMapping("/auth")
+@RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
 

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/controller/AuthController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/controller/AuthController.java
@@ -1,0 +1,47 @@
+package com.silsonfit.silsonfit_api.domain.auth.controller;
+
+import com.silsonfit.silsonfit_api.domain.auth.dto.LoginRequest;
+import com.silsonfit.silsonfit_api.domain.auth.dto.LoginResponse;
+import com.silsonfit.silsonfit_api.domain.auth.dto.TokenReissueRequest;
+import com.silsonfit.silsonfit_api.domain.auth.dto.TokenReissueResponse;
+import com.silsonfit.silsonfit_api.domain.auth.service.AuthService;
+import com.silsonfit.silsonfit_api.global.common.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 인증 관련 API
+ *
+ * 카카오 로그인과 토큰 재발급을 제공한다.
+ */
+@RestController
+@RequestMapping("/auth")
+@RequiredArgsConstructor
+public class AuthController {
+
+    private final AuthService authService;
+
+    /**
+     * 카카오 로그인.
+     *
+     * 클라이언트가 카카오 SDK로 받은 Access Token을 전달하면,
+     * 서비스의 Access/Refresh Token을 발급해 반환한다.
+     */
+    @PostMapping("/login")
+    public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
+        return ApiResponse.success(authService.login(request));
+    }
+
+    /**
+     * 토큰 재발급 (Refresh Token Rotation).
+     */
+    @PostMapping("/reissue")
+    public ApiResponse<TokenReissueResponse> reissue(
+            @Valid @RequestBody TokenReissueRequest request) {
+        return ApiResponse.success(authService.reissue(request));
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/controller/AuthController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/controller/AuthController.java
@@ -16,7 +16,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 인증 관련 API
  *
- * 카카오 로그인과 토큰 재발급을 제공한다.
+ * 카카오 로그인과 토큰 재발급 제공
  */
 @RestController
 @RequestMapping("/auth")
@@ -26,10 +26,10 @@ public class AuthController {
     private final AuthService authService;
 
     /**
-     * 카카오 로그인.
+     * 카카오 로그인
      *
-     * 클라이언트가 카카오 SDK로 받은 Access Token을 전달하면,
-     * 서비스의 Access/Refresh Token을 발급해 반환한다.
+     * 클라이언트가 카카오 SDK로 받은 Access Token 전달 시
+     * 서비스의 Access/Refresh Token 발급
      */
     @PostMapping("/login")
     public ApiResponse<LoginResponse> login(@Valid @RequestBody LoginRequest request) {
@@ -37,7 +37,7 @@ public class AuthController {
     }
 
     /**
-     * 토큰 재발급 (Refresh Token Rotation).
+     * 토큰 재발급 (Refresh Token Rotation)
      */
     @PostMapping("/reissue")
     public ApiResponse<TokenReissueResponse> reissue(

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/LoginRequest.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/LoginRequest.java
@@ -1,0 +1,14 @@
+package com.silsonfit.silsonfit_api.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 카카오 로그인 요청 DTO
+ *
+ * 클라이언트가 카카오 SDK로 발급받은 Access Token을 전달한다.
+ */
+public record LoginRequest(
+        @NotBlank(message = "kakaoToken은 필수입니다.")
+        String kakaoToken
+) {
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/LoginRequest.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/LoginRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 /**
  * 카카오 로그인 요청 DTO
  *
- * 클라이언트가 카카오 SDK로 발급받은 Access Token을 전달한다.
+ * 클라이언트가 카카오 SDK로 발급받은 Access Token 전달
  */
 public record LoginRequest(
         @NotBlank(message = "kakaoToken은 필수입니다.")

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/LoginResponse.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/LoginResponse.java
@@ -3,8 +3,8 @@ package com.silsonfit.silsonfit_api.domain.auth.dto;
 /**
  * 카카오 로그인 응답 DTO
  *
- * 서비스 Access/Refresh Token과 신규 가입 여부를 반환한다.
- * isNewUser가 true이면 클라이언트는 약관 동의 화면으로 분기한다.
+ * 서비스 Access/Refresh Token과 신규 가입 여부 반환
+ * isNewUser가 true이면 클라이언트는 약관 동의 화면으로 분기
  */
 public record LoginResponse(
         String accessToken,

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/LoginResponse.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/LoginResponse.java
@@ -1,0 +1,14 @@
+package com.silsonfit.silsonfit_api.domain.auth.dto;
+
+/**
+ * 카카오 로그인 응답 DTO
+ *
+ * 서비스 Access/Refresh Token과 신규 가입 여부를 반환한다.
+ * isNewUser가 true이면 클라이언트는 약관 동의 화면으로 분기한다.
+ */
+public record LoginResponse(
+        String accessToken,
+        String refreshToken,
+        boolean isNewUser
+) {
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/TokenReissueRequest.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/TokenReissueRequest.java
@@ -5,7 +5,7 @@ import jakarta.validation.constraints.NotBlank;
 /**
  * 토큰 재발급 요청 DTO
  *
- * 클라이언트가 보관 중인 Refresh Token을 전달하여 Access Token 재발급을 요청한다.
+ * 클라이언트가 보관 중인 Refresh Token 전달하여 Access Token 재발급 요청
  */
 public record TokenReissueRequest(
         @NotBlank(message = "refreshToken은 필수입니다.")

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/TokenReissueRequest.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/TokenReissueRequest.java
@@ -1,0 +1,14 @@
+package com.silsonfit.silsonfit_api.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 토큰 재발급 요청 DTO
+ *
+ * 클라이언트가 보관 중인 Refresh Token을 전달하여 Access Token 재발급을 요청한다.
+ */
+public record TokenReissueRequest(
+        @NotBlank(message = "refreshToken은 필수입니다.")
+        String refreshToken
+) {
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/TokenReissueResponse.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/TokenReissueResponse.java
@@ -3,8 +3,8 @@ package com.silsonfit.silsonfit_api.domain.auth.dto;
 /**
  * 토큰 재발급 응답 DTO
  *
- * Refresh Token Rotation 전략에 따라 Access와 Refresh Token 모두 새로 발급한다.
- * 응답 후 기존 Refresh Token은 DB에서 무효화된다.
+ * Refresh Token Rotation 전략에 따라 Access/Refresh Token 모두 새로 발급
+ * 응답 후 기존 Refresh Token은 DB에서 무효화
  */
 public record TokenReissueResponse(
         String accessToken,

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/TokenReissueResponse.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/TokenReissueResponse.java
@@ -1,0 +1,13 @@
+package com.silsonfit.silsonfit_api.domain.auth.dto;
+
+/**
+ * 토큰 재발급 응답 DTO
+ *
+ * Refresh Token Rotation 전략에 따라 Access와 Refresh Token 모두 새로 발급한다.
+ * 응답 후 기존 Refresh Token은 DB에서 무효화된다.
+ */
+public record TokenReissueResponse(
+        String accessToken,
+        String refreshToken
+) {
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/entity/RefreshToken.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/entity/RefreshToken.java
@@ -21,8 +21,8 @@ import java.time.LocalDateTime;
 /**
  * 리프레시 토큰 엔티티
  *
- * 로그인 시 발급되며 Access Token 재발급에 사용된다.
- * 사용자당 1개만 유지되고 재발급 시 Rotation 된다.
+ * 로그인 시 발급되며 Access Token 재발급에 사용
+ * 사용자당 1개만 유지, 재발급 시 Rotation
  */
 @Entity
 @Table(name = "refresh_tokens")
@@ -55,10 +55,7 @@ public class RefreshToken extends BaseCreatedTimeEntity {
     }
 
     /**
-     * 토큰 값과 만료 시각을 갱신한다 (Rotation).
-     *
-     * @param token      새 토큰 값
-     * @param expiresAt  새 만료 시각
+     * 토큰 값과 만료 시각 갱신 (Rotation)
      */
     public void updateToken(String token, LocalDateTime expiresAt) {
         this.token = token;
@@ -66,7 +63,7 @@ public class RefreshToken extends BaseCreatedTimeEntity {
     }
 
     /**
-     * 토큰이 만료되었는지 확인한다.
+     * 토큰 만료 여부 확인
      */
     public boolean isExpired() {
         return expiresAt.isBefore(LocalDateTime.now());

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/entity/RefreshToken.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/entity/RefreshToken.java
@@ -1,0 +1,74 @@
+package com.silsonfit.silsonfit_api.domain.auth.entity;
+
+import com.silsonfit.silsonfit_api.domain.user.entity.User;
+import com.silsonfit.silsonfit_api.global.common.BaseCreatedTimeEntity;
+import jakarta.persistence.Column;
+import jakarta.persistence.Entity;
+import jakarta.persistence.FetchType;
+import jakarta.persistence.GeneratedValue;
+import jakarta.persistence.GenerationType;
+import jakarta.persistence.Id;
+import jakarta.persistence.JoinColumn;
+import jakarta.persistence.OneToOne;
+import jakarta.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDateTime;
+
+/**
+ * 리프레시 토큰 엔티티
+ *
+ * 로그인 시 발급되며 Access Token 재발급에 사용된다.
+ * 사용자당 1개만 유지되고 재발급 시 Rotation 된다.
+ */
+@Entity
+@Table(name = "refresh_tokens")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class RefreshToken extends BaseCreatedTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 토큰 소유 사용자 (사용자당 1개)
+    @OneToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false, unique = true)
+    private User user;
+
+    // 리프레시 토큰 값
+    @Column(nullable = false, unique = true, length = 512)
+    private String token;
+
+    // 만료 시각
+    @Column(nullable = false)
+    private LocalDateTime expiresAt;
+
+    @Builder
+    public RefreshToken(User user, String token, LocalDateTime expiresAt) {
+        this.user = user;
+        this.token = token;
+        this.expiresAt = expiresAt;
+    }
+
+    /**
+     * 토큰 값과 만료 시각을 갱신한다 (Rotation).
+     *
+     * @param token      새 토큰 값
+     * @param expiresAt  새 만료 시각
+     */
+    public void updateToken(String token, LocalDateTime expiresAt) {
+        this.token = token;
+        this.expiresAt = expiresAt;
+    }
+
+    /**
+     * 토큰이 만료되었는지 확인한다.
+     */
+    public boolean isExpired() {
+        return expiresAt.isBefore(LocalDateTime.now());
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/repository/RefreshTokenRepository.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/repository/RefreshTokenRepository.java
@@ -1,0 +1,25 @@
+package com.silsonfit.silsonfit_api.domain.auth.repository;
+
+import com.silsonfit.silsonfit_api.domain.auth.entity.RefreshToken;
+import com.silsonfit.silsonfit_api.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
+
+    /**
+     * 토큰 값으로 RefreshToken을 조회한다.
+     */
+    Optional<RefreshToken> findByToken(String token);
+
+    /**
+     * 사용자로 RefreshToken을 조회한다 (사용자당 1개).
+     */
+    Optional<RefreshToken> findByUser(User user);
+
+    /**
+     * 사용자의 RefreshToken을 삭제한다 (로그아웃/탈퇴 시).
+     */
+    void deleteByUser(User user);
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/repository/RefreshTokenRepository.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/repository/RefreshTokenRepository.java
@@ -17,9 +17,4 @@ public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long
      * 사용자로 RefreshToken을 조회한다 (사용자당 1개).
      */
     Optional<RefreshToken> findByUser(User user);
-
-    /**
-     * 사용자의 RefreshToken을 삭제한다 (로그아웃/탈퇴 시).
-     */
-    void deleteByUser(User user);
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/repository/RefreshTokenRepository.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/repository/RefreshTokenRepository.java
@@ -9,12 +9,12 @@ import java.util.Optional;
 public interface RefreshTokenRepository extends JpaRepository<RefreshToken, Long> {
 
     /**
-     * 토큰 값으로 RefreshToken을 조회한다.
+     * 토큰 값으로 RefreshToken 조회
      */
     Optional<RefreshToken> findByToken(String token);
 
     /**
-     * 사용자로 RefreshToken을 조회한다 (사용자당 1개).
+     * 사용자로 RefreshToken 조회 (사용자당 1개)
      */
     Optional<RefreshToken> findByUser(User user);
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/service/AuthService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/service/AuthService.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 /**
  * 인증 관련 비즈니스 로직
  *
- * 카카오 로그인, 토큰 재발급을 처리한다.
+ * 카카오 로그인, 토큰 재발급 처리
  */
 @Service
 @RequiredArgsConstructor
@@ -35,13 +35,10 @@ public class AuthService {
     private final JwtTokenProvider jwtTokenProvider;
 
     /**
-     * 카카오 로그인 처리.
+     * 카카오 로그인 처리
      *
-     * 최초 로그인 시 사용자를 생성하고, Access/Refresh Token을 발급한다.
-     * 기존 사용자는 Refresh Token만 Rotation 한다.
-     *
-     * @param request 카카오 Access Token
-     * @return 서비스 토큰 및 신규 가입 여부
+     * 최초 로그인 시 사용자 생성 + Access/Refresh Token 발급
+     * 기존 사용자는 Refresh Token만 Rotation
      */
     @Transactional
     public LoginResponse login(LoginRequest request) {
@@ -72,13 +69,10 @@ public class AuthService {
     }
 
     /**
-     * Access Token 재발급 (Refresh Token Rotation).
+     * Access Token 재발급 (Refresh Token Rotation)
      *
-     * 기존 Refresh Token을 검증한 뒤, Access/Refresh Token 모두 새로 발급한다.
-     * 기존 Refresh Token은 DB 갱신을 통해 자연스럽게 무효화된다.
-     *
-     * @param request 재발급에 사용할 Refresh Token
-     * @return 새로 발급된 Access/Refresh Token
+     * 기존 Refresh Token 검증 후 Access/Refresh Token 모두 새로 발급
+     * 기존 Refresh Token은 DB 갱신으로 무효화
      */
     @Transactional
     public TokenReissueResponse reissue(TokenReissueRequest request) {
@@ -104,7 +98,7 @@ public class AuthService {
     }
 
     /**
-     * Refresh Token을 저장하거나, 기존 토큰이 있으면 Rotation 한다.
+     * Refresh Token 저장 또는 기존 토큰 Rotation
      */
     private void saveOrUpdateRefreshToken(User user, String token, LocalDateTime expiresAt) {
         refreshTokenRepository.findByUser(user).ifPresentOrElse(
@@ -120,7 +114,7 @@ public class AuthService {
     }
 
     /**
-     * 현재 시각을 기준으로 Refresh Token의 만료 시각을 계산한다.
+     * 현재 시각 기준 Refresh Token 만료 시각 계산
      */
     private LocalDateTime calculateRefreshExpiresAt() {
         return LocalDateTime.now()

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/service/AuthService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/service/AuthService.java
@@ -1,0 +1,129 @@
+package com.silsonfit.silsonfit_api.domain.auth.service;
+
+import com.silsonfit.silsonfit_api.domain.auth.client.KakaoClient;
+import com.silsonfit.silsonfit_api.domain.auth.dto.LoginRequest;
+import com.silsonfit.silsonfit_api.domain.auth.dto.LoginResponse;
+import com.silsonfit.silsonfit_api.domain.auth.dto.TokenReissueRequest;
+import com.silsonfit.silsonfit_api.domain.auth.dto.TokenReissueResponse;
+import com.silsonfit.silsonfit_api.domain.auth.entity.RefreshToken;
+import com.silsonfit.silsonfit_api.domain.auth.repository.RefreshTokenRepository;
+import com.silsonfit.silsonfit_api.domain.user.entity.User;
+import com.silsonfit.silsonfit_api.domain.user.repository.UserRepository;
+import com.silsonfit.silsonfit_api.global.auth.JwtTokenProvider;
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+/**
+ * 인증 관련 비즈니스 로직
+ *
+ * 카카오 로그인, 토큰 재발급을 처리한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class AuthService {
+
+    private final KakaoClient kakaoClient;
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    private final JwtTokenProvider jwtTokenProvider;
+
+    /**
+     * 카카오 로그인 처리.
+     *
+     * 최초 로그인 시 사용자를 생성하고, Access/Refresh Token을 발급한다.
+     * 기존 사용자는 Refresh Token만 Rotation 한다.
+     *
+     * @param request 카카오 Access Token
+     * @return 서비스 토큰 및 신규 가입 여부
+     */
+    @Transactional
+    public LoginResponse login(LoginRequest request) {
+        // 1) 카카오에서 사용자 정보 조회
+        KakaoClient.KakaoUserInfo kakaoUser =
+                kakaoClient.getUserInfo(request.kakaoToken());
+
+        // 2) socialId로 기존 사용자 조회, 없으면 신규 생성
+        Optional<User> existing = userRepository.findBySocialId(kakaoUser.id());
+        boolean isNewUser = existing.isEmpty();
+        User user = existing.orElseGet(() -> userRepository.save(
+                User.builder()
+                        .socialId(kakaoUser.id())
+                        .name(kakaoUser.name())
+                        .email(kakaoUser.email())
+                        .profileImageUrl(kakaoUser.profileImageUrl())
+                        .build()
+        ));
+
+        // 3) 토큰 발급 및 Refresh Token 저장/갱신
+        String accessToken = jwtTokenProvider.createAccessToken(user.getId());
+        String refreshTokenValue = jwtTokenProvider.createRefreshToken();
+        LocalDateTime expiresAt = calculateRefreshExpiresAt();
+
+        saveOrUpdateRefreshToken(user, refreshTokenValue, expiresAt);
+
+        return new LoginResponse(accessToken, refreshTokenValue, isNewUser);
+    }
+
+    /**
+     * Access Token 재발급 (Refresh Token Rotation).
+     *
+     * 기존 Refresh Token을 검증한 뒤, Access/Refresh Token 모두 새로 발급한다.
+     * 기존 Refresh Token은 DB 갱신을 통해 자연스럽게 무효화된다.
+     *
+     * @param request 재발급에 사용할 Refresh Token
+     * @return 새로 발급된 Access/Refresh Token
+     */
+    @Transactional
+    public TokenReissueResponse reissue(TokenReissueRequest request) {
+        // 1) 저장된 Refresh Token 조회
+        RefreshToken refreshToken = refreshTokenRepository
+                .findByToken(request.refreshToken())
+                .orElseThrow(() -> new BusinessException(ErrorCode.REFRESH_TOKEN_NOT_FOUND));
+
+        // 2) 만료 여부 확인
+        if (refreshToken.isExpired()) {
+            throw new BusinessException(ErrorCode.REFRESH_TOKEN_EXPIRED);
+        }
+
+        // 3) 새 토큰 발급 및 Rotation
+        User user = refreshToken.getUser();
+        String newAccessToken = jwtTokenProvider.createAccessToken(user.getId());
+        String newRefreshTokenValue = jwtTokenProvider.createRefreshToken();
+        LocalDateTime expiresAt = calculateRefreshExpiresAt();
+
+        refreshToken.updateToken(newRefreshTokenValue, expiresAt);
+
+        return new TokenReissueResponse(newAccessToken, newRefreshTokenValue);
+    }
+
+    /**
+     * Refresh Token을 저장하거나, 기존 토큰이 있으면 Rotation 한다.
+     */
+    private void saveOrUpdateRefreshToken(User user, String token, LocalDateTime expiresAt) {
+        refreshTokenRepository.findByUser(user).ifPresentOrElse(
+                existing -> existing.updateToken(token, expiresAt),
+                () -> refreshTokenRepository.save(
+                        RefreshToken.builder()
+                                .user(user)
+                                .token(token)
+                                .expiresAt(expiresAt)
+                                .build()
+                )
+        );
+    }
+
+    /**
+     * 현재 시각을 기준으로 Refresh Token의 만료 시각을 계산한다.
+     */
+    private LocalDateTime calculateRefreshExpiresAt() {
+        return LocalDateTime.now()
+                .plus(Duration.ofMillis(jwtTokenProvider.getRefreshTokenExpiration()));
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/entity/User.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/entity/User.java
@@ -1,0 +1,38 @@
+package com.silsonfit.silsonfit_api.domain.user.entity;
+
+import com.silsonfit.silsonfit_api.global.common.BaseTimeEntity;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 사용자 엔티티
+ *
+ * 카카오 소셜 로그인 기반 회원 정보를 관리한다.
+ */
+@Entity
+@Table(name = "users")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class User extends BaseTimeEntity {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 카카오 고유 ID
+    @Column(nullable = false, unique = true)
+    private Long socialId;
+
+    // 사용자 이름 (카카오에서 가져옴)
+    @Column(nullable = false)
+    private String name;
+
+    @Builder
+    public User(Long socialId, String name) {
+        this.socialId = socialId;
+        this.name = name;
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/entity/User.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/entity/User.java
@@ -10,7 +10,7 @@ import lombok.NoArgsConstructor;
 /**
  * 사용자 엔티티
  *
- * 카카오 소셜 로그인 기반 회원 정보를 관리한다.
+ * 카카오 소셜 로그인 기반 회원 정보 관리
  */
 @Entity
 @Table(name = "users")

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/entity/User.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/entity/User.java
@@ -30,9 +30,19 @@ public class User extends BaseTimeEntity {
     @Column(nullable = false)
     private String name;
 
+    // 이메일 (카카오 선택 동의 항목, 미동의 시 null)
+    @Column
+    private String email;
+
+    // 프로필 이미지 URL (카카오 선택 동의 항목, 미동의 시 null)
+    @Column
+    private String profileImageUrl;
+
     @Builder
-    public User(Long socialId, String name) {
+    public User(Long socialId, String name, String email, String profileImageUrl) {
         this.socialId = socialId;
         this.name = name;
+        this.email = email;
+        this.profileImageUrl = profileImageUrl;
     }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/repository/UserRepository.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/repository/UserRepository.java
@@ -1,0 +1,20 @@
+package com.silsonfit.silsonfit_api.domain.user.repository;
+
+import com.silsonfit.silsonfit_api.domain.user.entity.User;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * 사용자 Repository
+ */
+public interface UserRepository extends JpaRepository<User, Long> {
+
+    /**
+     * 카카오 소셜 ID로 사용자를 조회한다.
+     *
+     * @param socialId 카카오 고유 ID
+     * @return 사용자
+     */
+    Optional<User> findBySocialId(Long socialId);
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/repository/UserRepository.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/repository/UserRepository.java
@@ -11,10 +11,7 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     /**
-     * 카카오 소셜 ID로 사용자를 조회한다.
-     *
-     * @param socialId 카카오 고유 ID
-     * @return 사용자
+     * 카카오 소셜 ID로 사용자 조회
      */
     Optional<User> findBySocialId(Long socialId);
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/auth/CustomUserDetails.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/auth/CustomUserDetails.java
@@ -11,8 +11,8 @@ import java.util.Collections;
 /**
  * SecurityContext에 저장되는 인증 사용자 정보
  *
- * Access Token의 subject(userId)를 바탕으로 구성된다.
- * DB를 매번 조회하지 않고 토큰 자체의 정보만으로 인증을 처리한다.
+ * Access Token의 subject(userId) 기반 구성
+ * DB 조회 없이 토큰 정보만으로 인증 처리
  */
 @Getter
 @RequiredArgsConstructor

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/auth/CustomUserDetails.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/auth/CustomUserDetails.java
@@ -1,0 +1,57 @@
+package com.silsonfit.silsonfit_api.global.auth;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.Collection;
+import java.util.Collections;
+
+/**
+ * SecurityContext에 저장되는 인증 사용자 정보
+ *
+ * Access Token의 subject(userId)를 바탕으로 구성된다.
+ * DB를 매번 조회하지 않고 토큰 자체의 정보만으로 인증을 처리한다.
+ */
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final Long userId;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        return Collections.emptyList();
+    }
+
+    @Override
+    public String getPassword() {
+        return null;
+    }
+
+    @Override
+    public String getUsername() {
+        return String.valueOf(userId);
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/auth/JwtAuthenticationFilter.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/auth/JwtAuthenticationFilter.java
@@ -14,11 +14,10 @@ import org.springframework.web.filter.OncePerRequestFilter;
 import java.io.IOException;
 
 /**
- * Authorization 헤더의 Bearer 토큰을 검증하고
- * 검증 성공 시 SecurityContext에 인증 정보를 설정하는 필터
+ * Authorization 헤더의 Bearer 토큰 검증 필터
  *
- * 토큰이 없거나 유효하지 않은 경우 인증 없이 다음 필터로 넘긴다.
- * (SecurityConfig의 authorizeHttpRequests에서 최종 차단)
+ * 검증 성공 시 SecurityContext에 인증 정보 설정
+ * 토큰이 없거나 유효하지 않으면 인증 없이 다음 필터로 전달
  */
 @RequiredArgsConstructor
 public class JwtAuthenticationFilter extends OncePerRequestFilter {
@@ -51,8 +50,8 @@ public class JwtAuthenticationFilter extends OncePerRequestFilter {
     }
 
     /**
-     * Authorization 헤더에서 Bearer 토큰 값을 추출한다.
-     * 헤더가 없거나 Bearer prefix가 없으면 null을 반환한다.
+     * Authorization 헤더에서 Bearer 토큰 값 추출
+     * 헤더가 없거나 Bearer prefix가 없으면 null 반환
      */
     private String resolveToken(HttpServletRequest request) {
         String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/auth/JwtAuthenticationFilter.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/auth/JwtAuthenticationFilter.java
@@ -1,0 +1,64 @@
+package com.silsonfit.silsonfit_api.global.auth;
+
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+/**
+ * Authorization 헤더의 Bearer 토큰을 검증하고
+ * 검증 성공 시 SecurityContext에 인증 정보를 설정하는 필터
+ *
+ * 토큰이 없거나 유효하지 않은 경우 인증 없이 다음 필터로 넘긴다.
+ * (SecurityConfig의 authorizeHttpRequests에서 최종 차단)
+ */
+@RequiredArgsConstructor
+public class JwtAuthenticationFilter extends OncePerRequestFilter {
+
+    private static final String BEARER_PREFIX = "Bearer ";
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    protected void doFilterInternal(
+            HttpServletRequest request,
+            HttpServletResponse response,
+            FilterChain chain
+    ) throws ServletException, IOException {
+
+        String token = resolveToken(request);
+
+        if (StringUtils.hasText(token) && jwtTokenProvider.validateToken(token)) {
+            Long userId = jwtTokenProvider.getUserId(token);
+
+            CustomUserDetails userDetails = new CustomUserDetails(userId);
+            UsernamePasswordAuthenticationToken authentication =
+                    new UsernamePasswordAuthenticationToken(
+                            userDetails, null, userDetails.getAuthorities());
+
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+        }
+
+        chain.doFilter(request, response);
+    }
+
+    /**
+     * Authorization 헤더에서 Bearer 토큰 값을 추출한다.
+     * 헤더가 없거나 Bearer prefix가 없으면 null을 반환한다.
+     */
+    private String resolveToken(HttpServletRequest request) {
+        String authHeader = request.getHeader(HttpHeaders.AUTHORIZATION);
+        if (StringUtils.hasText(authHeader) && authHeader.startsWith(BEARER_PREFIX)) {
+            return authHeader.substring(BEARER_PREFIX.length());
+        }
+        return null;
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/auth/JwtTokenProvider.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/auth/JwtTokenProvider.java
@@ -3,6 +3,7 @@ package com.silsonfit.silsonfit_api.global.auth;
 import io.jsonwebtoken.Claims;
 import io.jsonwebtoken.Jwts;
 import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
@@ -13,11 +14,12 @@ import java.util.Base64;
 import java.util.Date;
 
 /**
- * JWT 토큰 생성/파싱/검증을 담당하는 Provider
+ * JWT 토큰 생성/파싱/검증 Provider
  *
- * Access Token: userId를 subject로 하는 JWT
- * Refresh Token: 무작위 바이트를 Base64로 인코딩한 문자열 (DB 조회용)
+ * Access Token: userId를 subject로 포함하는 JWT
+ * Refresh Token: Base64 인코딩 랜덤 문자열 (DB 조회용)
  */
+@Slf4j
 @Component
 public class JwtTokenProvider {
 
@@ -36,9 +38,7 @@ public class JwtTokenProvider {
     }
 
     /**
-     * Access Token을 생성한다.
-     *
-     * @param userId 사용자 ID (subject로 저장)
+     * Access Token 생성
      */
     public String createAccessToken(Long userId) {
         Date now = new Date();
@@ -53,8 +53,7 @@ public class JwtTokenProvider {
     }
 
     /**
-     * Refresh Token을 생성한다 (DB 조회용 랜덤 문자열).
-     * claims를 포함하지 않는다.
+     * Refresh Token 생성 (DB 조회용 랜덤 문자열, claims 미포함)
      */
     public String createRefreshToken() {
         byte[] randomBytes = new byte[32];
@@ -63,27 +62,28 @@ public class JwtTokenProvider {
     }
 
     /**
-     * Access Token에서 userId를 추출한다.
+     * Access Token에서 userId 추출
      */
     public Long getUserId(String token) {
         return Long.valueOf(parseClaims(token).getSubject());
     }
 
     /**
-     * Access Token의 유효성을 검증한다.
-     * 서명 불일치, 만료, 형식 오류 시 false를 반환한다.
+     * Access Token 유효성 검증
+     * 서명 불일치, 만료, 형식 오류 시 false 반환
      */
     public boolean validateToken(String token) {
         try {
             parseClaims(token);
             return true;
         } catch (Exception e) {
+            log.debug("토큰 검증 실패: {}", e.getMessage());
             return false;
         }
     }
 
     /**
-     * Refresh Token의 만료 시각(ms)을 반환한다.
+     * Refresh Token 만료 시각(ms) 반환
      */
     public long getRefreshTokenExpiration() {
         return refreshTokenExpiration;

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/auth/JwtTokenProvider.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/auth/JwtTokenProvider.java
@@ -1,0 +1,99 @@
+package com.silsonfit.silsonfit_api.global.auth;
+
+import io.jsonwebtoken.Claims;
+import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.security.Keys;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
+
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.security.SecureRandom;
+import java.util.Base64;
+import java.util.Date;
+
+/**
+ * JWT 토큰 생성/파싱/검증을 담당하는 Provider
+ *
+ * Access Token: userId를 subject로 하는 JWT
+ * Refresh Token: 무작위 바이트를 Base64로 인코딩한 문자열 (DB 조회용)
+ */
+@Component
+public class JwtTokenProvider {
+
+    private final SecretKey key;
+    private final long accessTokenExpiration;
+    private final long refreshTokenExpiration;
+
+    public JwtTokenProvider(
+            @Value("${jwt.secret}") String secret,
+            @Value("${jwt.access-token-expiration}") long accessTokenExpiration,
+            @Value("${jwt.refresh-token-expiration}") long refreshTokenExpiration
+    ) {
+        this.key = Keys.hmacShaKeyFor(secret.getBytes(StandardCharsets.UTF_8));
+        this.accessTokenExpiration = accessTokenExpiration;
+        this.refreshTokenExpiration = refreshTokenExpiration;
+    }
+
+    /**
+     * Access Token을 생성한다.
+     *
+     * @param userId 사용자 ID (subject로 저장)
+     */
+    public String createAccessToken(Long userId) {
+        Date now = new Date();
+        Date expiry = new Date(now.getTime() + accessTokenExpiration);
+
+        return Jwts.builder()
+                .subject(String.valueOf(userId))
+                .issuedAt(now)
+                .expiration(expiry)
+                .signWith(key)
+                .compact();
+    }
+
+    /**
+     * Refresh Token을 생성한다 (DB 조회용 랜덤 문자열).
+     * claims를 포함하지 않는다.
+     */
+    public String createRefreshToken() {
+        byte[] randomBytes = new byte[32];
+        new SecureRandom().nextBytes(randomBytes);
+        return Base64.getUrlEncoder().withoutPadding().encodeToString(randomBytes);
+    }
+
+    /**
+     * Access Token에서 userId를 추출한다.
+     */
+    public Long getUserId(String token) {
+        return Long.valueOf(parseClaims(token).getSubject());
+    }
+
+    /**
+     * Access Token의 유효성을 검증한다.
+     * 서명 불일치, 만료, 형식 오류 시 false를 반환한다.
+     */
+    public boolean validateToken(String token) {
+        try {
+            parseClaims(token);
+            return true;
+        } catch (Exception e) {
+            return false;
+        }
+    }
+
+    /**
+     * Refresh Token의 만료 시각(ms)을 반환한다.
+     */
+    public long getRefreshTokenExpiration() {
+        return refreshTokenExpiration;
+    }
+
+    private Claims parseClaims(String token) {
+        return Jwts.parser()
+                .verifyWith(key)
+                .build()
+                .parseSignedClaims(token)
+                .getPayload();
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
@@ -19,6 +19,10 @@ public enum ErrorCode {
     // ── Auth ──
     INVALID_TOKEN(401, "유효하지 않은 토큰입니다."),
     EXPIRED_TOKEN(401, "만료된 토큰입니다."),
+    INVALID_KAKAO_TOKEN(401, "유효하지 않은 카카오 토큰입니다."),
+    KAKAO_SERVER_ERROR(502, "카카오 서버와의 통신에 실패했습니다."),
+    REFRESH_TOKEN_NOT_FOUND(401, "리프레시 토큰을 찾을 수 없습니다."),
+    REFRESH_TOKEN_EXPIRED(401, "만료된 리프레시 토큰입니다."),
 
     // ── User ──
     USER_NOT_FOUND(404, "사용자를 찾을 수 없습니다."),

--- a/silsonfit-api/src/main/resources/application-dev.yml
+++ b/silsonfit-api/src/main/resources/application-dev.yml
@@ -22,6 +22,10 @@ spring:
       hibernate:
         format_sql: true
 
+jwt:
+  # 로컬 개발용 공유 secret. HS256 기준 최소 32자 필요.
+  secret: silsonfit-dev-secret-for-local-development-only-32chars
+
 management:
   endpoint:
     health:

--- a/silsonfit-api/src/main/resources/application-prod.yml
+++ b/silsonfit-api/src/main/resources/application-prod.yml
@@ -10,6 +10,9 @@ spring:
       ddl-auto: validate
     show-sql: false
 
+jwt:
+  secret: ${JWT_SECRET}
+
 management:
   endpoint:
     health:

--- a/silsonfit-api/src/main/resources/application.yml
+++ b/silsonfit-api/src/main/resources/application.yml
@@ -9,14 +9,10 @@ spring:
     active: dev
 
 jwt:
-  secret: ${JWT_SECRET}
-  access-token-expiration: 3600000      # 60분 (ms)
-  refresh-token-expiration: 1209600000  # 14일 (ms)
+  access-token-expiration: 3600000      # 60분
+  refresh-token-expiration: 1209600000  # 14일
 
 kakao:
-  client-id: ${KAKAO_CLIENT_ID}
-  redirect-uri: ${KAKAO_REDIRECT_URI}
-  token-uri: https://kauth.kakao.com/oauth/token
   user-info-uri: https://kapi.kakao.com/v2/user/me
 
 management:

--- a/silsonfit-api/src/main/resources/application.yml
+++ b/silsonfit-api/src/main/resources/application.yml
@@ -8,6 +8,17 @@ spring:
   profiles:
     active: dev
 
+jwt:
+  secret: ${JWT_SECRET}
+  access-token-expiration: 3600000      # 60분 (ms)
+  refresh-token-expiration: 1209600000  # 14일 (ms)
+
+kakao:
+  client-id: ${KAKAO_CLIENT_ID}
+  redirect-uri: ${KAKAO_REDIRECT_URI}
+  token-uri: https://kauth.kakao.com/oauth/token
+  user-info-uri: https://kapi.kakao.com/v2/user/me
+
 management:
   endpoints:
     web:

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/auth/client/KakaoClientTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/auth/client/KakaoClientTest.java
@@ -23,8 +23,8 @@ import static org.springframework.test.web.client.response.MockRestResponseCreat
 /**
  * KakaoClient 통합 테스트
  *
- * MockRestServiceServer로 카카오 API 응답을 스텁한 뒤,
- * RestClient 호출 → JSON 파싱 → KakaoUserInfo 반환 흐름을 검증한다.
+ * MockRestServiceServer로 카카오 API 응답 스텁 후
+ * RestClient 호출 → JSON 파싱 → KakaoUserInfo 반환 흐름 검증
  */
 class KakaoClientTest {
 

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/auth/client/KakaoClientTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/auth/client/KakaoClientTest.java
@@ -1,0 +1,116 @@
+package com.silsonfit.silsonfit_api.domain.auth.client;
+
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.header;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withStatus;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * KakaoClient 통합 테스트
+ *
+ * MockRestServiceServer로 카카오 API 응답을 스텁한 뒤,
+ * RestClient 호출 → JSON 파싱 → KakaoUserInfo 반환 흐름을 검증한다.
+ */
+class KakaoClientTest {
+
+    private static final String KAKAO_USER_INFO_URI = "https://kapi.kakao.com/v2/user/me";
+
+    private MockRestServiceServer server;
+    private KakaoClient kakaoClient;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder();
+        this.server = MockRestServiceServer.bindTo(builder).build();
+        this.kakaoClient = new KakaoClient(KAKAO_USER_INFO_URI, builder);
+    }
+
+    @Test
+    @DisplayName("정상 응답 시 id/name/email/profileImageUrl 모두 매핑된다")
+    void getUserInfo_success() {
+        server.expect(requestTo(KAKAO_USER_INFO_URI))
+                .andExpect(method(HttpMethod.GET))
+                .andExpect(header(HttpHeaders.AUTHORIZATION, "Bearer test-token"))
+                .andRespond(withSuccess("""
+                        {
+                          "id": 12345,
+                          "kakao_account": {
+                            "email": "test@example.com",
+                            "profile": {
+                              "nickname": "홍길동",
+                              "profile_image_url": "http://example.com/img.jpg"
+                            }
+                          }
+                        }
+                        """, MediaType.APPLICATION_JSON));
+
+        KakaoClient.KakaoUserInfo info = kakaoClient.getUserInfo("test-token");
+
+        assertThat(info.id()).isEqualTo(12345L);
+        assertThat(info.name()).isEqualTo("홍길동");
+        assertThat(info.email()).isEqualTo("test@example.com");
+        assertThat(info.profileImageUrl()).isEqualTo("http://example.com/img.jpg");
+    }
+
+    @Test
+    @DisplayName("선택 동의 항목(email, profile_image_url) 미포함 응답은 null로 처리된다")
+    void getUserInfo_optional_fields_null() {
+        server.expect(requestTo(KAKAO_USER_INFO_URI))
+                .andRespond(withSuccess("""
+                        {
+                          "id": 12345,
+                          "kakao_account": {
+                            "profile": {
+                              "nickname": "홍길동"
+                            }
+                          }
+                        }
+                        """, MediaType.APPLICATION_JSON));
+
+        KakaoClient.KakaoUserInfo info = kakaoClient.getUserInfo("test-token");
+
+        assertThat(info.id()).isEqualTo(12345L);
+        assertThat(info.name()).isEqualTo("홍길동");
+        assertThat(info.email()).isNull();
+        assertThat(info.profileImageUrl()).isNull();
+    }
+
+    @Test
+    @DisplayName("401 응답은 INVALID_KAKAO_TOKEN으로 변환된다")
+    void getUserInfo_401_invalidKakaoToken() {
+        server.expect(requestTo(KAKAO_USER_INFO_URI))
+                .andRespond(withStatus(HttpStatus.UNAUTHORIZED));
+
+        assertThatThrownBy(() -> kakaoClient.getUserInfo("invalid"))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_KAKAO_TOKEN);
+    }
+
+    @Test
+    @DisplayName("5xx 응답은 KAKAO_SERVER_ERROR로 변환된다")
+    void getUserInfo_5xx_kakaoServerError() {
+        server.expect(requestTo(KAKAO_USER_INFO_URI))
+                .andRespond(withStatus(HttpStatus.INTERNAL_SERVER_ERROR));
+
+        assertThatThrownBy(() -> kakaoClient.getUserInfo("token"))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.KAKAO_SERVER_ERROR);
+    }
+}

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/auth/service/AuthServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/auth/service/AuthServiceTest.java
@@ -34,8 +34,8 @@ import static org.mockito.Mockito.verify;
 /**
  * AuthService 단위 테스트
  *
- * Mockito로 의존성을 격리한 순수 단위 테스트.
- * 비즈니스 로직(신규/기존 사용자 분기, Refresh Token Rotation, 예외 분기)을 검증한다.
+ * Mockito로 의존성 격리한 순수 단위 테스트
+ * 비즈니스 로직(신규/기존 사용자 분기, Refresh Token Rotation, 예외 분기) 검증
  */
 @ExtendWith(MockitoExtension.class)
 class AuthServiceTest {

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/auth/service/AuthServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/auth/service/AuthServiceTest.java
@@ -1,0 +1,200 @@
+package com.silsonfit.silsonfit_api.domain.auth.service;
+
+import com.silsonfit.silsonfit_api.domain.auth.client.KakaoClient;
+import com.silsonfit.silsonfit_api.domain.auth.dto.LoginRequest;
+import com.silsonfit.silsonfit_api.domain.auth.dto.LoginResponse;
+import com.silsonfit.silsonfit_api.domain.auth.dto.TokenReissueRequest;
+import com.silsonfit.silsonfit_api.domain.auth.dto.TokenReissueResponse;
+import com.silsonfit.silsonfit_api.domain.auth.entity.RefreshToken;
+import com.silsonfit.silsonfit_api.domain.auth.repository.RefreshTokenRepository;
+import com.silsonfit.silsonfit_api.domain.user.entity.User;
+import com.silsonfit.silsonfit_api.domain.user.repository.UserRepository;
+import com.silsonfit.silsonfit_api.global.auth.JwtTokenProvider;
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+/**
+ * AuthService 단위 테스트
+ *
+ * Mockito로 의존성을 격리한 순수 단위 테스트.
+ * 비즈니스 로직(신규/기존 사용자 분기, Refresh Token Rotation, 예외 분기)을 검증한다.
+ */
+@ExtendWith(MockitoExtension.class)
+class AuthServiceTest {
+
+    private static final long REFRESH_TTL_MS = 1_209_600_000L; // 14일
+
+    @Mock
+    private KakaoClient kakaoClient;
+    @Mock
+    private UserRepository userRepository;
+    @Mock
+    private RefreshTokenRepository refreshTokenRepository;
+    @Mock
+    private JwtTokenProvider jwtTokenProvider;
+
+    @InjectMocks
+    private AuthService authService;
+
+    // ──────────── login ────────────
+
+    @Test
+    @DisplayName("신규 사용자 로그인 시 User와 RefreshToken을 저장하고 isNewUser=true로 응답한다")
+    void login_newUser() {
+        // given
+        given(kakaoClient.getUserInfo("kakao-access")).willReturn(
+                new KakaoClient.KakaoUserInfo(111L, "홍길동", "email@test.com", "http://img"));
+        given(userRepository.findBySocialId(111L)).willReturn(Optional.empty());
+
+        User savedUser = userWithId(1L, 111L);
+        given(userRepository.save(any(User.class))).willReturn(savedUser);
+        given(jwtTokenProvider.createAccessToken(1L)).willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken()).willReturn("refresh-token");
+        given(jwtTokenProvider.getRefreshTokenExpiration()).willReturn(REFRESH_TTL_MS);
+        given(refreshTokenRepository.findByUser(savedUser)).willReturn(Optional.empty());
+
+        // when
+        LoginResponse response = authService.login(new LoginRequest("kakao-access"));
+
+        // then
+        assertThat(response.accessToken()).isEqualTo("access-token");
+        assertThat(response.refreshToken()).isEqualTo("refresh-token");
+        assertThat(response.isNewUser()).isTrue();
+        verify(userRepository).save(any(User.class));
+        verify(refreshTokenRepository).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("기존 사용자 로그인 시 User 저장은 건너뛰고 RefreshToken을 Rotation 한다")
+    void login_existingUser_rotation() {
+        // given
+        User user = userWithId(1L, 222L);
+        given(kakaoClient.getUserInfo("kakao-access")).willReturn(
+                new KakaoClient.KakaoUserInfo(222L, "홍길동", null, null));
+        given(userRepository.findBySocialId(222L)).willReturn(Optional.of(user));
+        given(jwtTokenProvider.createAccessToken(1L)).willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken()).willReturn("new-refresh");
+        given(jwtTokenProvider.getRefreshTokenExpiration()).willReturn(REFRESH_TTL_MS);
+
+        RefreshToken existing = RefreshToken.builder()
+                .user(user)
+                .token("old-refresh")
+                .expiresAt(LocalDateTime.now().plusDays(7))
+                .build();
+        given(refreshTokenRepository.findByUser(user)).willReturn(Optional.of(existing));
+
+        // when
+        LoginResponse response = authService.login(new LoginRequest("kakao-access"));
+
+        // then
+        assertThat(response.isNewUser()).isFalse();
+        assertThat(existing.getToken()).isEqualTo("new-refresh"); // Rotation 반영 확인
+        verify(userRepository, never()).save(any(User.class));
+        verify(refreshTokenRepository, never()).save(any(RefreshToken.class));
+    }
+
+    @Test
+    @DisplayName("기존 사용자인데 RefreshToken이 DB에 없으면 새로 save 한다")
+    void login_existingUser_noRefresh_thenSave() {
+        // given
+        User user = userWithId(1L, 333L);
+        given(kakaoClient.getUserInfo("kakao-access")).willReturn(
+                new KakaoClient.KakaoUserInfo(333L, "홍길동", null, null));
+        given(userRepository.findBySocialId(333L)).willReturn(Optional.of(user));
+        given(jwtTokenProvider.createAccessToken(1L)).willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken()).willReturn("refresh");
+        given(jwtTokenProvider.getRefreshTokenExpiration()).willReturn(REFRESH_TTL_MS);
+        given(refreshTokenRepository.findByUser(user)).willReturn(Optional.empty());
+
+        // when
+        authService.login(new LoginRequest("kakao-access"));
+
+        // then
+        verify(refreshTokenRepository, times(1)).save(any(RefreshToken.class));
+    }
+
+    // ──────────── reissue ────────────
+
+    @Test
+    @DisplayName("재발급 성공 시 새 Access/Refresh 발급하고 기존 Refresh를 Rotation 한다")
+    void reissue_success() {
+        // given
+        User user = userWithId(1L, 111L);
+        RefreshToken stored = RefreshToken.builder()
+                .user(user)
+                .token("old-refresh")
+                .expiresAt(LocalDateTime.now().plusDays(7))
+                .build();
+        given(refreshTokenRepository.findByToken("old-refresh"))
+                .willReturn(Optional.of(stored));
+        given(jwtTokenProvider.createAccessToken(1L)).willReturn("new-access");
+        given(jwtTokenProvider.createRefreshToken()).willReturn("new-refresh");
+        given(jwtTokenProvider.getRefreshTokenExpiration()).willReturn(REFRESH_TTL_MS);
+
+        // when
+        TokenReissueResponse response =
+                authService.reissue(new TokenReissueRequest("old-refresh"));
+
+        // then
+        assertThat(response.accessToken()).isEqualTo("new-access");
+        assertThat(response.refreshToken()).isEqualTo("new-refresh");
+        assertThat(stored.getToken()).isEqualTo("new-refresh"); // DB 엔티티 Rotation 반영
+    }
+
+    @Test
+    @DisplayName("재발급 요청 토큰이 DB에 없으면 REFRESH_TOKEN_NOT_FOUND 예외")
+    void reissue_tokenNotFound() {
+        given(refreshTokenRepository.findByToken("missing")).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.reissue(new TokenReissueRequest("missing")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.REFRESH_TOKEN_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("재발급 요청 토큰이 만료됐으면 REFRESH_TOKEN_EXPIRED 예외")
+    void reissue_tokenExpired() {
+        User user = userWithId(1L, 111L);
+        RefreshToken expired = RefreshToken.builder()
+                .user(user)
+                .token("expired")
+                .expiresAt(LocalDateTime.now().minusMinutes(1))
+                .build();
+        given(refreshTokenRepository.findByToken("expired")).willReturn(Optional.of(expired));
+
+        assertThatThrownBy(() -> authService.reissue(new TokenReissueRequest("expired")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.REFRESH_TOKEN_EXPIRED);
+    }
+
+    // ──────────── helper ────────────
+
+    private User userWithId(Long id, Long socialId) {
+        User user = User.builder()
+                .socialId(socialId)
+                .name("name")
+                .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+}

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/global/auth/JwtTokenProviderTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/global/auth/JwtTokenProviderTest.java
@@ -1,0 +1,119 @@
+package com.silsonfit.silsonfit_api.global.auth;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * JwtTokenProvider 단위 테스트
+ *
+ * Spring 컨텍스트 없이 순수 단위 테스트로 검증한다.
+ */
+class JwtTokenProviderTest {
+
+    private static final String SECRET = "test-secret-for-unit-test-minimum-32-characters-long";
+    private static final long ACCESS_TOKEN_EXPIRATION = 3_600_000L;      // 60분
+    private static final long REFRESH_TOKEN_EXPIRATION = 1_209_600_000L; // 14일
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    @BeforeEach
+    void setUp() {
+        jwtTokenProvider = new JwtTokenProvider(
+                SECRET, ACCESS_TOKEN_EXPIRATION, REFRESH_TOKEN_EXPIRATION);
+    }
+
+    @Test
+    @DisplayName("Access Token을 생성하면 subject의 userId를 정상적으로 추출할 수 있다")
+    void createAccessTokenAndGetUserId() {
+        Long userId = 1L;
+
+        String token = jwtTokenProvider.createAccessToken(userId);
+        Long extracted = jwtTokenProvider.getUserId(token);
+
+        assertThat(extracted).isEqualTo(userId);
+    }
+
+    @Test
+    @DisplayName("유효한 Access Token은 검증에 통과한다")
+    void validateValidToken() {
+        String token = jwtTokenProvider.createAccessToken(1L);
+
+        boolean valid = jwtTokenProvider.validateToken(token);
+
+        assertThat(valid).isTrue();
+    }
+
+    @Test
+    @DisplayName("페이로드가 변조된 토큰은 서명 불일치로 검증에 실패한다")
+    void validateTamperedToken() {
+        String token = jwtTokenProvider.createAccessToken(1L);
+
+        // 페이로드 영역(첫 번째 '.' 바로 뒤)의 한 글자를 다른 문자로 변조
+        int firstDot = token.indexOf('.');
+        char[] chars = token.toCharArray();
+        chars[firstDot + 1] = (chars[firstDot + 1] == 'A') ? 'B' : 'A';
+        String tampered = new String(chars);
+
+        boolean valid = jwtTokenProvider.validateToken(tampered);
+
+        assertThat(valid).isFalse();
+    }
+
+    @Test
+    @DisplayName("다른 secret으로 서명된 토큰은 검증에 실패한다")
+    void validateTokenSignedByDifferentSecret() {
+        JwtTokenProvider other = new JwtTokenProvider(
+                "different-secret-for-test-minimum-32-characters",
+                ACCESS_TOKEN_EXPIRATION,
+                REFRESH_TOKEN_EXPIRATION);
+        String otherToken = other.createAccessToken(1L);
+
+        boolean valid = jwtTokenProvider.validateToken(otherToken);
+
+        assertThat(valid).isFalse();
+    }
+
+    @Test
+    @DisplayName("만료된 토큰은 검증에 실패한다")
+    void validateExpiredToken() throws InterruptedException {
+        // 만료 시간을 1ms로 설정한 Provider
+        JwtTokenProvider shortLived = new JwtTokenProvider(
+                SECRET, 1L, REFRESH_TOKEN_EXPIRATION);
+        String token = shortLived.createAccessToken(1L);
+
+        // 만료 대기
+        Thread.sleep(10);
+
+        boolean valid = shortLived.validateToken(token);
+
+        assertThat(valid).isFalse();
+    }
+
+    @Test
+    @DisplayName("JWT 형식이 아닌 문자열은 검증에 실패한다")
+    void validateMalformedToken() {
+        boolean valid = jwtTokenProvider.validateToken("not.a.jwt");
+
+        assertThat(valid).isFalse();
+    }
+
+    @Test
+    @DisplayName("Refresh Token은 호출마다 서로 다른 값을 생성한다")
+    void createRefreshTokenIsUnique() {
+        String token1 = jwtTokenProvider.createRefreshToken();
+        String token2 = jwtTokenProvider.createRefreshToken();
+
+        assertThat(token1).isNotEqualTo(token2);
+    }
+
+    @Test
+    @DisplayName("Refresh Token 만료 시간(ms)을 반환한다")
+    void getRefreshTokenExpiration() {
+        long expiration = jwtTokenProvider.getRefreshTokenExpiration();
+
+        assertThat(expiration).isEqualTo(REFRESH_TOKEN_EXPIRATION);
+    }
+}


### PR DESCRIPTION
<!-- PR의 타입은 Label을 통해 나타내주세요. -->

### 💻 작업 내용
<!-- 진행한 작업 내용에 대해 작성해주세요. -->
- KakaoClient 카카오  API 사용자 정보 조회 구현
- AuthService 로그인(자동 회원가입) 및 토큰 재발급 구현
- AuthController Post /auth/login, POST /auth/reissue 엔드포인트 구현
- User 엔티티 email, profileImageUrl 필드 추가
- Auth 에러코드 추가
- KakaoClientTest, AuthServiceTest 테스트 추가

### ✨ 리뷰 포인트
<!-- (ex) query 가 너무 복잡한 것 같은데 이 위주로 봐주세요. -->
- SecurityConfig에 JWT 필터 등록은 별도 PR로 분리할 예정입니다. 현재는 필터가 등록되지 않은 상태입니다.
- Refresh Token 만료 기간을 14일로 설정했는데 적절한지 의견 부탁드립니다.

### 📝 메모
<!-- PR 관련 전달사항이 있다면 이곳에 작성해주세요. -->
- 카카오 닉네임은 필수 동의 항목으로 생각하여 nullable로 만들지 않았습니다.
- User 엔티티에 email, profileImageUrl 필드를 추가했습니다. 현재 ERD에는 없지만 마이페이지에서 이미지와 이메일을 표시하고 있어 매번 카카오 서버에 API 요청을 보내는 것보다 DB에 저장하고 있는 것이 성능적으로 나을 것 같아서 필드를 추가했습니다. 
- 응답/에러코드 포맷(현재 int → 도메인 접두사 방식 ex: Auth: AU_001,  Analysis_History: AN_001 ) 방식은 어떤지 의견 부탁드립니다.
- AuthController에 /api prefix 추가 프론트/백엔드 구분을 위해 모든 컨트롤러에 사용
### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
closed #12
