### PR TITLE
feat: SecurityConfig JWT 필터 등록 (#16)

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/SecurityConfig.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/SecurityConfig.java
@@ -1,34 +1,66 @@
 package com.silsonfit.silsonfit_api.global.config;
 
-
+import com.silsonfit.silsonfit_api.global.auth.JwtAuthenticationFilter;
+import com.silsonfit.silsonfit_api.global.auth.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
 import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import jakarta.servlet.http.HttpServletResponse;
 
+/**
+ * Spring Security 설정
+ *
+ * JWT 인증 필터 등록, 세션 STATELESS, 경로별 인증 정책 설정
+ */
 @Configuration
+@RequiredArgsConstructor
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
         http
-                // 초기 개발 단계에서는 CSRF 비활성화
+                // CSRF 비활성화 (JWT 사용)
                 .csrf(AbstractHttpConfigurer::disable)
 
                 // H2 콘솔 사용을 위해 sameOrigin 허용
                 .headers(headers -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::sameOrigin))
 
+                // 세션 미사용 (JWT 기반 인증)
+                .sessionManagement(session ->
+                        session.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
+
                 // form login / http basic 비활성화
                 .formLogin(AbstractHttpConfigurer::disable)
                 .httpBasic(AbstractHttpConfigurer::disable)
+
+                // 인증 실패 시 401 + ApiResponse 형태로 반환
+                .exceptionHandling(exception -> exception
+                        .authenticationEntryPoint((request, response, authException) -> {
+                            response.setStatus(HttpServletResponse.SC_UNAUTHORIZED);
+                            response.setContentType("application/json;charset=UTF-8");
+                            response.getWriter().write(
+                                    "{\"code\":401,\"message\":\"인증이 필요합니다.\",\"data\":null}");
+                        }))
+
+                // JWT 필터 등록
+                .addFilterBefore(
+                        new JwtAuthenticationFilter(jwtTokenProvider),
+                        UsernamePasswordAuthenticationFilter.class)
 
                 // 요청 허용 정책
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers(
                                 "/",
                                 "/error",
+                                "/api/auth/**",
                                 "/h2-console/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
@@ -36,7 +68,7 @@ public class SecurityConfig {
                                 "/actuator/health",
                                 "/actuator/info"
                         ).permitAll()
-                        .anyRequest().permitAll()
+                        .anyRequest().authenticated()
                 );
 
         return http.build();

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/SecurityConfig.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/SecurityConfig.java
@@ -13,11 +13,6 @@ import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import jakarta.servlet.http.HttpServletResponse;
 
-/**
- * Spring Security 설정
- *
- * JWT 인증 필터 등록, 세션 STATELESS, 경로별 인증 정책 설정
- */
 @Configuration
 @RequiredArgsConstructor
 public class SecurityConfig {

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/global/config/SecurityConfigTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/global/config/SecurityConfigTest.java
@@ -1,0 +1,53 @@
+package com.silsonfit.silsonfit_api.global.config;
+
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.AutoConfigureMockMvc;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+/**
+ * SecurityConfig 통합 테스트
+ *
+ * 경로별 인증 정책 검증
+ */
+@SpringBootTest
+@AutoConfigureMockMvc
+class SecurityConfigTest {
+
+    @Autowired
+    private MockMvc mockMvc;
+
+    // ──────────── 비인증 경로 (permitAll) ────────────
+
+    @Test
+    @DisplayName("Swagger UI는 토큰 없이 접근 가능")
+    void swaggerUi_permitAll() throws Exception {
+        mockMvc.perform(get("/swagger-ui/index.html"))
+                .andExpect(status().isOk());
+    }
+
+    @Test
+    @DisplayName("Actuator health는 토큰 없이 접근 가능")
+    void actuatorHealth_permitAll() throws Exception {
+        mockMvc.perform(get("/actuator/health"))
+                .andExpect(status().isOk());
+    }
+
+    // ──────────── 인증 경로 (authenticated) ────────────
+
+    @Test
+    @DisplayName("인증 필요한 경로에 토큰 없이 접근 시 401 + ApiResponse 형태 반환")
+    void protectedEndpoint_without_token_returns401() throws Exception {
+        mockMvc.perform(get("/api/protected/test"))
+                .andExpect(status().isUnauthorized())
+                .andExpect(jsonPath("$.code").value(401))
+                .andExpect(jsonPath("$.message").value("인증이 필요합니다."))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+}


### PR DESCRIPTION
<!-- PR의 타입은 Label을 통해 나타내주세요. -->

### 💻 작업 내용
<!-- 진행한 작업 내용에 대해 작성해주세요. -->
-  JwtAuthenticationFilter를 SecurityFilterChain에 등록
- SessionCreationPolicy.STATELESS 설정
- 비인증 경로 설정 (/api/auth/**, Swagger, H2, actuator)
- 인증 실패 시 401 + ApiResponse 형태로 응답 통일
- SecurityConfig 인증 정책 테스트 추가

### 📝 메모
<!-- PR 관련 전달사항이 있다면 이곳에 작성해주세요. -->
- 이전 anyRequest().permitAll()에서 anyRequest().authenticated()로 변경했습니다.
- JWT 기반 인증이라 세션을 사용하지 않으므로 STATELESS로 설정했습니다.
- 인증 필요한 API를 추가할 때는 별도 설정 없이 컨트롤러만 만들면 됩니다. 비인증 API가 필요하면 SecurityConfig의 requestMatchers에 경로를 추가해주세요.

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
closed #16 
