### PR TITLE
feat: 약관 동의 API 구현(#18)

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/controller/AuthController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/controller/AuthController.java
@@ -2,12 +2,15 @@ package com.silsonfit.silsonfit_api.domain.auth.controller;
 
 import com.silsonfit.silsonfit_api.domain.auth.dto.LoginRequest;
 import com.silsonfit.silsonfit_api.domain.auth.dto.LoginResponse;
+import com.silsonfit.silsonfit_api.domain.auth.dto.TermsAgreeRequest;
 import com.silsonfit.silsonfit_api.domain.auth.dto.TokenReissueRequest;
 import com.silsonfit.silsonfit_api.domain.auth.dto.TokenReissueResponse;
 import com.silsonfit.silsonfit_api.domain.auth.service.AuthService;
+import com.silsonfit.silsonfit_api.global.auth.CustomUserDetails;
 import com.silsonfit.silsonfit_api.global.common.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -16,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 인증 관련 API
  *
- * 카카오 로그인과 토큰 재발급 제공
+ * 카카오 로그인, 토큰 재발급, 약관 동의 제공
  */
 @RestController
 @RequestMapping("/api/auth")
@@ -43,5 +46,16 @@ public class AuthController {
     public ApiResponse<TokenReissueResponse> reissue(
             @Valid @RequestBody TokenReissueRequest request) {
         return ApiResponse.success(authService.reissue(request));
+    }
+
+    /**
+     * 약관 동의 (신규 회원 가입 완료 처리)
+     */
+    @PostMapping("/terms")
+    public ApiResponse<Void> agreeTerms(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody TermsAgreeRequest request) {
+        authService.agreeTerms(userDetails.getUserId());
+        return ApiResponse.success();
     }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/TermsAgreeRequest.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/TermsAgreeRequest.java
@@ -1,0 +1,18 @@
+package com.silsonfit.silsonfit_api.domain.auth.dto;
+
+import jakarta.validation.constraints.AssertTrue;
+
+/**
+ * 약관 동의 요청 DTO
+ */
+public record TermsAgreeRequest(
+        @AssertTrue(message = "만 14세 이상이어야 합니다.")
+        boolean ageOver14,
+
+        @AssertTrue(message = "서비스 이용약관에 동의해야 합니다.")
+        boolean serviceTerms,
+
+        @AssertTrue(message = "개인정보 수집 및 이용에 동의해야 합니다.")
+        boolean privacyPolicy
+) {
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/service/AuthService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/service/AuthService.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 /**
  * 인증 관련 비즈니스 로직
  *
- * 카카오 로그인, 토큰 재발급 처리
+ * 카카오 로그인, 토큰 재발급, 약관 동의 처리
  */
 @Service
 @RequiredArgsConstructor
@@ -95,6 +95,23 @@ public class AuthService {
         refreshToken.updateToken(newRefreshTokenValue, expiresAt);
 
         return new TokenReissueResponse(newAccessToken, newRefreshTokenValue);
+    }
+
+    /**
+     * 약관 동의 처리
+     *
+     * 신규 회원의 약관 동의를 저장하여 가입 완료 처리
+     */
+    @Transactional
+    public void agreeTerms(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.getTermsAgreedAt() != null) {
+            throw new BusinessException(ErrorCode.ALREADY_AGREED_TERMS);
+        }
+
+        user.agreeTerms();
     }
 
     /**

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/entity/User.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/entity/User.java
@@ -7,6 +7,8 @@ import lombok.Builder;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
 
+import java.time.LocalDateTime;
+
 /**
  * 사용자 엔티티
  *
@@ -38,11 +40,22 @@ public class User extends BaseTimeEntity {
     @Column
     private String profileImageUrl;
 
+    // 약관 동의 시각 (null이면 미동의)
+    @Column
+    private LocalDateTime termsAgreedAt;
+
     @Builder
     public User(Long socialId, String name, String email, String profileImageUrl) {
         this.socialId = socialId;
         this.name = name;
         this.email = email;
         this.profileImageUrl = profileImageUrl;
+    }
+
+    /**
+     * 약관 동의 처리
+     */
+    public void agreeTerms() {
+        this.termsAgreedAt = LocalDateTime.now();
     }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/SecurityConfig.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/SecurityConfig.java
@@ -55,7 +55,8 @@ public class SecurityConfig {
                         .requestMatchers(
                                 "/",
                                 "/error",
-                                "/api/auth/**",
+                                "/api/auth/login",
+                                "/api/auth/reissue",
                                 "/h2-console/**",
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
@@ -23,6 +23,7 @@ public enum ErrorCode {
     KAKAO_SERVER_ERROR(502, "카카오 서버와의 통신에 실패했습니다."),
     REFRESH_TOKEN_NOT_FOUND(401, "리프레시 토큰을 찾을 수 없습니다."),
     REFRESH_TOKEN_EXPIRED(401, "만료된 리프레시 토큰입니다."),
+    ALREADY_AGREED_TERMS(409, "이미 약관에 동의한 사용자입니다."),
 
     // ── User ──
     USER_NOT_FOUND(404, "사용자를 찾을 수 없습니다."),

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/auth/service/AuthServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/auth/service/AuthServiceTest.java
@@ -187,6 +187,48 @@ class AuthServiceTest {
                 .isEqualTo(ErrorCode.REFRESH_TOKEN_EXPIRED);
     }
 
+    // ──────────── agreeTerms ────────────
+
+    @Test
+    @DisplayName("약관 동의 성공 시 termsAgreedAt이 설정된다")
+    void agreeTerms_success() {
+        // given
+        User user = userWithId(1L, 111L);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        // when
+        authService.agreeTerms(1L);
+
+        // then
+        assertThat(user.getTermsAgreedAt()).isNotNull();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자의 약관 동의 시 USER_NOT_FOUND 예외")
+    void agreeTerms_userNotFound() {
+        given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> authService.agreeTerms(999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("이미 약관 동의한 사용자가 다시 요청 시 ALREADY_AGREED_TERMS 예외")
+    void agreeTerms_alreadyAgreed() {
+        // given
+        User user = userWithId(1L, 111L);
+        user.agreeTerms(); // 이미 동의
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> authService.agreeTerms(1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.ALREADY_AGREED_TERMS);
+    }
+
     // ──────────── helper ────────────
 
     private User userWithId(Long id, Long socialId) {


### PR DESCRIPTION
<!-- PR의 타입은 Label을 통해 나타내주세요. -->

### 💻 작업 내용
<!-- 진행한 작업 내용에 대해 작성해주세요. -->
- POST /api/auth/terms 약관 동의 API 구현
- 요청 DTO: ageOver14, serviceTerms, privacyPolicy (3개 모두 true 필수, @Valid 검증)
- 중복 동의 시 'ALREADY_AGREED_TERMS' 응답
- 약관 동의 서비스 단위 테스트 3개 추가

### ✨ 리뷰 포인트
<!-- (ex) query 가 너무 복잡한 것 같은데 이 위주로 봐주세요. -->
- User Entity에 'termsAgreedAt' 필드 추가했습니다. 별도 테이블 만들기에는 과하다고 느껴 필드 1개만 추가했습니다.

### 📝 메모
<!-- PR 관련 전달사항이 있다면 이곳에 작성해주세요. -->
- 약관 3개 모두 필수라 프론트에서 전부 체크 후 요청 백엔드는 개별 저장 없이 동의 시점만 기록합니다

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
closed #18
