### PR TITLE
feat: 로그아웃 API 구현 (#23)

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/controller/AuthController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/controller/AuthController.java
@@ -2,6 +2,8 @@ package com.silsonfit.silsonfit_api.domain.auth.controller;
 
 import com.silsonfit.silsonfit_api.domain.auth.dto.LoginRequest;
 import com.silsonfit.silsonfit_api.domain.auth.dto.LoginResponse;
+import com.silsonfit.silsonfit_api.domain.auth.dto.LogoutRequest;
+import com.silsonfit.silsonfit_api.domain.auth.dto.LogoutResponse;
 import com.silsonfit.silsonfit_api.domain.auth.dto.TermsAgreeRequest;
 import com.silsonfit.silsonfit_api.domain.auth.dto.TokenReissueRequest;
 import com.silsonfit.silsonfit_api.domain.auth.dto.TokenReissueResponse;
@@ -19,7 +21,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 인증 관련 API
  *
- * 카카오 로그인, 토큰 재발급, 약관 동의 제공
+ * 카카오 로그인, 토큰 재발급, 약관 동의, 로그아웃 제공
  */
 @RestController
 @RequestMapping("/api/auth")
@@ -57,5 +59,15 @@ public class AuthController {
             @Valid @RequestBody TermsAgreeRequest request) {
         authService.agreeTerms(userDetails.getUserId());
         return ApiResponse.success();
+    }
+
+    /**
+     * 로그아웃 (Refresh Token 무효화)
+     */
+    @PostMapping("/logout")
+    public ApiResponse<LogoutResponse> logout(
+            @Valid @RequestBody LogoutRequest request) {
+        authService.logout(request.refreshToken());
+        return ApiResponse.success(new LogoutResponse(true));
     }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/LogoutRequest.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/LogoutRequest.java
@@ -1,0 +1,12 @@
+package com.silsonfit.silsonfit_api.domain.auth.dto;
+
+import jakarta.validation.constraints.NotBlank;
+
+/**
+ * 로그아웃 요청 DTO
+ */
+public record LogoutRequest(
+        @NotBlank(message = "refreshToken은 필수입니다.")
+        String refreshToken
+) {
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/LogoutResponse.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/dto/LogoutResponse.java
@@ -1,0 +1,9 @@
+package com.silsonfit.silsonfit_api.domain.auth.dto;
+
+/**
+ * 로그아웃 응답 DTO
+ */
+public record LogoutResponse(
+        boolean success
+) {
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/service/AuthService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/service/AuthService.java
@@ -23,7 +23,7 @@ import java.util.Optional;
 /**
  * 인증 관련 비즈니스 로직
  *
- * 카카오 로그인, 토큰 재발급, 약관 동의 처리
+ * 카카오 로그인, 토큰 재발급, 약관 동의, 로그아웃 처리
  */
 @Service
 @RequiredArgsConstructor
@@ -112,6 +112,19 @@ public class AuthService {
         }
 
         user.agreeTerms();
+    }
+
+    /**
+     * 로그아웃 처리
+     *
+     * Refresh Token을 DB에서 삭제하여 토큰 재발급 차단
+     */
+    @Transactional
+    public void logout(String refreshToken) {
+        RefreshToken token = refreshTokenRepository.findByToken(refreshToken)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN));
+
+        refreshTokenRepository.delete(token);
     }
 
     /**

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
@@ -24,6 +24,7 @@ public enum ErrorCode {
     REFRESH_TOKEN_NOT_FOUND(401, "리프레시 토큰을 찾을 수 없습니다."),
     REFRESH_TOKEN_EXPIRED(401, "만료된 리프레시 토큰입니다."),
     ALREADY_AGREED_TERMS(409, "이미 약관에 동의한 사용자입니다."),
+    INVALID_REFRESH_TOKEN(400, "유효하지 않은 리프레시 토큰입니다."),
 
     // ── User ──
     USER_NOT_FOUND(404, "사용자를 찾을 수 없습니다."),

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/auth/service/AuthServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/auth/service/AuthServiceTest.java
@@ -229,6 +229,42 @@ class AuthServiceTest {
                 .isEqualTo(ErrorCode.ALREADY_AGREED_TERMS);
     }
 
+    // ──────────── logout ────────────
+
+    @Test
+    @DisplayName("로그아웃 성공 시 Refresh Token이 삭제된다")
+    void logout_success() {
+        // given
+        User user = userWithId(1L, 111L);
+        RefreshToken stored = RefreshToken.builder()
+                .user(user)
+                .token("valid-refresh")
+                .expiresAt(LocalDateTime.now().plusDays(7))
+                .build();
+        given(refreshTokenRepository.findByToken("valid-refresh"))
+                .willReturn(Optional.of(stored));
+
+        // when
+        authService.logout("valid-refresh");
+
+        // then
+        verify(refreshTokenRepository).delete(stored);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 Refresh Token으로 로그아웃 시 INVALID_REFRESH_TOKEN 예외")
+    void logout_invalidToken() {
+        // given
+        given(refreshTokenRepository.findByToken("invalid-token"))
+                .willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> authService.logout("invalid-token"))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
+    }
+
     // ──────────── helper ────────────
 
     private User userWithId(Long id, Long socialId) {


### PR DESCRIPTION
<!-- PR의 타입은 Label을 통해 나타내주세요. -->

### 💻 작업 내용
<!-- 진행한 작업 내용에 대해 작성해주세요. -->
- 로그아웃 Post /api/auth/logout API 구현
- 클라이언트가 보낸 Refresh Token을 DB에서 조회 후 삭제하여 토큰 재발급 차단
- 'INVALID_REFRESH_TOKEN(400) 에러코드 추가
- 로그아웃 서비스 테스트 2개 추가 (성공, 잘못된 토큰)

### ✨ 리뷰 포인트
<!-- (ex) query 가 너무 복잡한 것 같은데 이 위주로 봐주세요. -->
- ErrorCode에 'INVALID_REFRESH_TOKEN(400)' 추가했습니다. 토큰을 찾을 수 없다는 기존의 'REFRESH_TOKEN_NOT_FOUND(401)'는 reissue용이라 로그아웃과 재발급 과정의 에러코드를 분리하였습니다.
- Refresh Token 조회 후 해당 객체를 바로 삭제하는 방식으로 구현했습니다. deleteByToken 대신 delete(entity)로 불필요한 SELECT 쿼리 1회 줄이는 방식으로 구현했습니다.

### 📝 메모
<!-- PR 관련 전달사항이 있다면 이곳에 작성해주세요. -->

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
closed #23
