### PR TITLE
feat: 내 프로필 조회 및 닉네임 수정 API

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/controller/UserController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/controller/UserController.java
@@ -1,0 +1,48 @@
+package com.silsonfit.silsonfit_api.domain.user.controller;
+
+import com.silsonfit.silsonfit_api.domain.user.dto.UserResponse;
+import com.silsonfit.silsonfit_api.domain.user.dto.UserUpdateRequest;
+import com.silsonfit.silsonfit_api.domain.user.service.UserService;
+import com.silsonfit.silsonfit_api.global.auth.CustomUserDetails;
+import com.silsonfit.silsonfit_api.global.common.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 사용자 프로필 API
+ *
+ * 내 정보 조회 및 닉네임 수정 제공
+ */
+@RestController
+@RequestMapping("/api/user")
+@RequiredArgsConstructor
+public class UserController {
+
+    private final UserService userService;
+
+    /**
+     * 내 프로필 조회
+     */
+    @GetMapping("/me")
+    public ApiResponse<UserResponse> getMyProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ApiResponse.success(userService.getMyProfile(userDetails.getUserId()));
+    }
+
+    /**
+     * 닉네임 수정
+     */
+    @PatchMapping("/me")
+    public ApiResponse<Void> updateMyProfile(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody UserUpdateRequest request) {
+        userService.updateMyProfile(userDetails.getUserId(), request);
+        return ApiResponse.success();
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/dto/UserResponse.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/dto/UserResponse.java
@@ -1,0 +1,11 @@
+package com.silsonfit.silsonfit_api.domain.user.dto;
+
+/**
+ * 내 프로필 조회 응답 DTO
+ */
+public record UserResponse(
+        Long userId,
+        String name,
+        String email
+) {
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/dto/UserUpdateRequest.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/dto/UserUpdateRequest.java
@@ -1,0 +1,16 @@
+package com.silsonfit.silsonfit_api.domain.user.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+import jakarta.validation.constraints.Size;
+
+/**
+ * 닉네임 수정 요청 DTO
+ */
+public record UserUpdateRequest(
+        @NotBlank(message = "닉네임은 필수입니다.")
+        @Size(max = 50, message = "닉네임은 50자 이내여야 합니다.")
+        @Pattern(regexp = "^[가-힣a-zA-Z0-9]+$", message = "한글, 영문, 숫자만 사용 가능합니다.")
+        String name
+) {
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/entity/User.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/entity/User.java
@@ -58,4 +58,11 @@ public class User extends BaseTimeEntity {
     public void agreeTerms() {
         this.termsAgreedAt = LocalDateTime.now();
     }
+
+    /**
+     * 닉네임 수정
+     */
+    public void updateName(String name) {
+        this.name = name;
+    }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/service/NicknameValidator.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/service/NicknameValidator.java
@@ -1,0 +1,40 @@
+package com.silsonfit.silsonfit_api.domain.user.service;
+
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * 닉네임 금칙어 검증
+ *
+ * 욕설, 성적 표현, 비하 표현 등을 포함한 닉네임을 차단
+ */
+@Component
+public class NicknameValidator {
+
+    private static final List<String> FORBIDDEN_WORDS = List.of(
+            // 욕설
+            "시발", "씨발", "시bal", "ㅅㅂ", "ㅆㅂ", "씹", "좆", "지랄", "개새끼",
+            "병신", "ㅂㅅ", "미친놈", "미친년", "꺼져", "닥쳐",
+            // 성적 표현
+            "섹스", "야동", "포르노", "성인", "자위",
+            // 비하 표현
+            "느금마", "한남", "한녀", "틀딱", "급식충"
+    );
+
+    /**
+     * 금칙어 포함 여부 검증
+     *
+     * @param nickname 검증할 닉네임
+     */
+    public void validate(String nickname) {
+        String lower = nickname.toLowerCase();
+        for (String word : FORBIDDEN_WORDS) {
+            if (lower.contains(word.toLowerCase())) {
+                throw new BusinessException(ErrorCode.INVALID_NICKNAME);
+            }
+        }
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/service/UserService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/service/UserService.java
@@ -1,0 +1,45 @@
+package com.silsonfit.silsonfit_api.domain.user.service;
+
+import com.silsonfit.silsonfit_api.domain.user.dto.UserResponse;
+import com.silsonfit.silsonfit_api.domain.user.dto.UserUpdateRequest;
+import com.silsonfit.silsonfit_api.domain.user.entity.User;
+import com.silsonfit.silsonfit_api.domain.user.repository.UserRepository;
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 사용자 프로필 관련 비즈니스 로직
+ */
+@Service
+@RequiredArgsConstructor
+public class UserService {
+
+    private final UserRepository userRepository;
+    private final NicknameValidator nicknameValidator;
+
+    /**
+     * 내 프로필 조회
+     */
+    @Transactional(readOnly = true)
+    public UserResponse getMyProfile(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        return new UserResponse(user.getId(), user.getName(), user.getEmail());
+    }
+
+    /**
+     * 닉네임 수정
+     */
+    @Transactional
+    public void updateMyProfile(Long userId, UserUpdateRequest request) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        nicknameValidator.validate(request.name());
+        user.updateName(request.name());
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     // ── User ──
     USER_NOT_FOUND(404, "사용자를 찾을 수 없습니다."),
     DEACTIVATED_USER(403, "탈퇴한 사용자입니다."),
+    INVALID_NICKNAME(400, "사용할 수 없는 닉네임입니다."),
 
     // ── Analysis ──
     HISTORY_NOT_FOUND(404, "해당 분석 이력을 찾을 수 없습니다."),

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/user/service/UserServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/user/service/UserServiceTest.java
@@ -1,0 +1,126 @@
+package com.silsonfit.silsonfit_api.domain.user.service;
+
+import com.silsonfit.silsonfit_api.domain.user.dto.UserResponse;
+import com.silsonfit.silsonfit_api.domain.user.dto.UserUpdateRequest;
+import com.silsonfit.silsonfit_api.domain.user.entity.User;
+import com.silsonfit.silsonfit_api.domain.user.repository.UserRepository;
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * UserService 단위 테스트
+ *
+ * 프로필 조회 및 닉네임 수정 비즈니스 로직 검증
+ */
+@ExtendWith(MockitoExtension.class)
+class UserServiceTest {
+
+    @Mock
+    private UserRepository userRepository;
+
+    @Spy
+    private NicknameValidator nicknameValidator;
+
+    @InjectMocks
+    private UserService userService;
+
+    // ──────────── getMyProfile ────────────
+
+    @Test
+    @DisplayName("내 프로필 조회 성공")
+    void getMyProfile_success() {
+        // given
+        User user = userWithId(1L, 111L, "홍길동", "hong@test.com");
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        // when
+        UserResponse response = userService.getMyProfile(1L);
+
+        // then
+        assertThat(response.userId()).isEqualTo(1L);
+        assertThat(response.name()).isEqualTo("홍길동");
+        assertThat(response.email()).isEqualTo("hong@test.com");
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 프로필 조회 시 USER_NOT_FOUND 예외")
+    void getMyProfile_userNotFound() {
+        // given
+        given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.getMyProfile(999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    // ──────────── updateMyProfile ────────────
+
+    @Test
+    @DisplayName("닉네임 수정 성공 시 엔티티의 이름이 변경된다")
+    void updateMyProfile_success() {
+        // given
+        User user = userWithId(1L, 111L, "홍길동", "hong@test.com");
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        // when
+        userService.updateMyProfile(1L, new UserUpdateRequest("김철수"));
+
+        // then
+        assertThat(user.getName()).isEqualTo("김철수");
+    }
+
+    @Test
+    @DisplayName("금칙어가 포함된 닉네임 수정 시 INVALID_NICKNAME 예외")
+    void updateMyProfile_forbiddenWord() {
+        // given
+        User user = userWithId(1L, 111L, "홍길동", "hong@test.com");
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateMyProfile(1L, new UserUpdateRequest("시발놈")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_NICKNAME);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 닉네임 수정 시 USER_NOT_FOUND 예외")
+    void updateMyProfile_userNotFound() {
+        // given
+        given(userRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> userService.updateMyProfile(999L, new UserUpdateRequest("김철수")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_NOT_FOUND);
+    }
+
+    // ──────────── helper ────────────
+
+    private User userWithId(Long id, Long socialId, String name, String email) {
+        User user = User.builder()
+                .socialId(socialId)
+                .name(name)
+                .email(email)
+                .build();
+        ReflectionTestUtils.setField(user, "id", id);
+        return user;
+    }
+}


### PR DESCRIPTION
<!-- PR의 타입은 Label을 통해 나타내주세요. -->

### 💻 작업 내용
<!-- 진행한 작업 내용에 대해 작성해주세요. -->
- 내 프로필 조회 GET /api/user/me
- 내 닉네임 수정 PATCH /api/user/me
- 닉네임 검증 (50자 제한, 특수문자 차단, 금칙어 필터링)
- UserController, UserService, DTO, 테스트 코드 작성

### ✨ 리뷰 포인트
<!-- (ex) query 가 너무 복잡한 것 같은데 이 위주로 봐주세요. -->
- 이름은 중복이 될 수 있고, 이름을 수정할 때 특수문자, 금칙어 제한 필터링을 뒀습니다. 근데 현재 금칙어 제한 필터링은 하드코딩되어 있는데 이 방식이 괜찮을지 다른 방법으로는 외부 API 써서 필터링 하는 방식도 있습니다.

### 📝 메모
<!-- PR 관련 전달사항이 있다면 이곳에 작성해주세요. -->

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
closed #25 
