### PR TITLE
feat: 실손 보험 계산 도메인 기반 설계

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/dto/CalculationRequest.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/dto/CalculationRequest.java
@@ -1,0 +1,41 @@
+package com.silsonfit.silsonfit_api.domain.calculation.dto;
+
+import com.silsonfit.silsonfit_api.domain.calculation.enums.PurposeType;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.VisitType;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Positive;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 실손 보험 계산 요청 DTO
+ */
+@Getter
+@NoArgsConstructor
+public class CalculationRequest {
+
+    /** 보험 ID */
+    @NotNull
+    private Long insuranceId;
+
+    /** 의료비 */
+    @NotNull
+    @Positive
+    private Integer medicalCost;
+
+    /** 진료 유형 */
+    @NotNull
+    private VisitType visitType;
+
+    /** 진료 항목 */
+    @NotNull
+    private TreatmentCategory treatmentCategory;
+
+    /** 진료 목적 */
+    @NotNull
+    private PurposeType purposeType;
+
+    /** EDI 코드 (선택) */
+    private String ediCode;
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/dto/CalculationResponse.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/dto/CalculationResponse.java
@@ -1,0 +1,41 @@
+package com.silsonfit.silsonfit_api.domain.calculation.dto;
+
+import com.silsonfit.silsonfit_api.domain.calculation.vo.CalculationResult;
+import lombok.Builder;
+import lombok.Getter;
+
+import java.util.List;
+
+/**
+ * 실손 보험 계산 응답 DTO
+ */
+@Getter
+@Builder
+public class CalculationResponse {
+
+    /** 보장 여부 */
+    private Boolean isCovered;
+
+    /** 예상 환급액 */
+    private Integer refundAmount;
+
+    /** 총 자기부담금 */
+    private Integer deductibleAmount;
+
+    /** 계산 근거 */
+    private List<String> basis;
+
+    /** 면책/주의사항 */
+    private String disclaimer;
+
+    /** VO → DTO 변환 */
+    public static CalculationResponse from(CalculationResult result) {
+        return CalculationResponse.builder()
+                .isCovered(result.getIsCovered())
+                .refundAmount(result.getRefundAmount())
+                .deductibleAmount(result.getDeductibleAmount())
+                .basis(result.getBasis())
+                .disclaimer(result.getDisclaimer())
+                .build();
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/entity/CalculationHistory.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/entity/CalculationHistory.java
@@ -1,0 +1,94 @@
+package com.silsonfit.silsonfit_api.domain.calculation.entity;
+
+import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
+import com.silsonfit.silsonfit_api.global.common.BaseCreatedTimeEntity;
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 실손 보험 계산 이력 엔티티
+ */
+@Entity
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CalculationHistory extends BaseCreatedTimeEntity {
+
+    /** 계산 이력 PK */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "calculation_history_id")
+    private Long id;
+
+    // ===== 1. 요청 스냅샷 =====
+
+    /** 사용자 식별자 */
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    /** 보험 ID */
+    @Column(name = "insurance_id", nullable = false)
+    private Long insuranceId;
+
+    /** 의료비 입력값 */
+    @Column(name = "medical_cost", nullable = false)
+    private Integer medicalCost;
+
+    /** 진료 항목 */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "treatment_category", nullable = false)
+    private TreatmentCategory treatmentCategory;
+
+    /** EDI 코드 */
+    @Column(name = "edi_code")
+    private String ediCode;
+
+    // ===== 2. 계산 결과 =====
+
+    /** 보장 여부 */
+    @Column(name = "is_covered", nullable = false)
+    private Boolean isCovered;
+
+    /** 예상 환급액 */
+    @Column(name = "refund_amount", nullable = false)
+    private Integer refundAmount;
+
+    /** 총 자기부담금 */
+    @Column(name = "deductible_amount", nullable = false)
+    private Integer deductibleAmount;
+
+    // ===== 3. 부가 정보 =====
+
+    /** 즐겨찾기 여부 */
+    @Column(name = "is_favorite", nullable = false)
+    @Builder.Default
+    private Boolean isFavorite = false;
+
+    public static CalculationHistory create(
+            Long userId,
+            Long insuranceId,
+            Integer medicalCost,
+            TreatmentCategory treatmentCategory,
+            String ediCode,
+            Boolean isCovered,
+            Integer refundAmount,
+            Integer deductibleAmount
+    ) {
+        return CalculationHistory.builder()
+                .userId(userId)
+                .insuranceId(insuranceId)
+                .medicalCost(medicalCost)
+                .treatmentCategory(treatmentCategory)
+                .ediCode(ediCode)
+                .isCovered(isCovered)
+                .refundAmount(refundAmount)
+                .deductibleAmount(deductibleAmount)
+                .build();
+    }
+
+    /** 즐겨찾기 토글 */
+    public void toggleFavorite() {
+        this.isFavorite = !this.isFavorite;
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/entity/CoverageRule.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/entity/CoverageRule.java
@@ -1,0 +1,103 @@
+package com.silsonfit.silsonfit_api.domain.calculation.entity;
+
+import com.silsonfit.silsonfit_api.domain.calculation.enums.PurposeType;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.VisitType;
+import jakarta.persistence.*;
+import lombok.*;
+
+/**
+ * 보험별 보장 계산 룰 엔티티
+ *
+ */
+@Entity
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class CoverageRule {
+
+    /** 보장 룰 PK */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "coverage_rule_id")
+    private Long id;
+
+    /** 보험 ID */
+    @Column(name = "insurance_id", nullable = false)
+    private Long insuranceId;
+
+    /** EDI 코드 */
+    @Column(name = "edi_code")
+    private String ediCode;
+
+    /** 진료 유형 */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "visit_type", nullable = false)
+    private VisitType visitType;
+
+    /** 진료 항목 */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "treatment_category", nullable = false)
+    private TreatmentCategory treatmentCategory;
+
+    /** 진료 목적 */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "purpose_type", nullable = false)
+    private PurposeType purposeType;
+
+    /** 보장 여부 */
+    @Column(name = "is_covered", nullable = false)
+    private Boolean isCovered;
+
+    /** 보장률 (%) */
+    @Column(name = "coverage_rate", nullable = false)
+    private Integer coverageRate;
+
+    /** 고정 자기부담금 */
+    @Column(name = "deductible_amount", nullable = false)
+    private Integer deductibleAmount;
+
+    /** 최대 보장 한도 */
+    @Column(name = "limit_amount")
+    private Integer limitAmount;
+
+    /** 계산 근거 설명 */
+    @Column(name = "basis", nullable = false)
+    private String basis;
+
+    /** 면책 또는 주의사항 */
+    @Column(name = "disclaimer")
+    private String disclaimer;
+
+    /**
+     * 보장 룰 생성
+     */
+    public static CoverageRule create(
+            Long insuranceId,
+            String ediCode,
+            VisitType visitType,
+            TreatmentCategory treatmentCategory,
+            PurposeType purposeType,
+            Boolean isCovered,
+            Integer coverageRate,
+            Integer deductibleAmount,
+            Integer limitAmount,
+            String basis,
+            String disclaimer
+    ) {
+        return CoverageRule.builder()
+                .insuranceId(insuranceId)
+                .ediCode(ediCode)
+                .visitType(visitType)
+                .treatmentCategory(treatmentCategory)
+                .purposeType(purposeType)
+                .isCovered(isCovered)
+                .coverageRate(coverageRate)
+                .deductibleAmount(deductibleAmount)
+                .limitAmount(limitAmount)
+                .basis(basis)
+                .disclaimer(disclaimer)
+                .build();
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/entity/EdiCode.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/entity/EdiCode.java
@@ -1,0 +1,135 @@
+package com.silsonfit.silsonfit_api.domain.calculation.entity;
+
+import com.silsonfit.silsonfit_api.domain.calculation.enums.FeeType;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.PayType;
+import jakarta.persistence.*;
+import lombok.*;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * EDI 수가 코드 엔티티
+ *
+ * - 건강보험 청구 기준의 수가(행위) 정보를 저장하는 원본 데이터 테이블
+ * - 공공데이터 API(수가 정보)를 기반으로 적재된다.
+ * - 보험 보장 판단의 직접 기준이 아니라, CoverageRule 매칭을 위한 입력 데이터로 사용된다.
+ */
+@Entity
+@Getter
+@Builder(access = AccessLevel.PRIVATE)
+@AllArgsConstructor(access = AccessLevel.PROTECTED)
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Table(name = "edi_code")
+public class EdiCode {
+
+    /** EDI 코드 PK */
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    @Column(name = "edi_code_id")
+    private Long id;
+
+    /**
+     * 수가 코드
+     * - 건강보험 행위 코드 (예: Z3000030)
+     * - 동일 코드라도 적용 시점에 따라 값이 달라질 수 있음
+     */
+    @Column(name = "code", nullable = false, length = 20)
+    private String code;
+
+    /**
+     * 수가 한글명
+     * - 진료/처치/검사 등의 명칭
+     */
+    @Column(name = "treatment_name", nullable = false)
+    private String treatmentName;
+
+    /**
+     * 수가 분류 번호
+     * - 행위 분류 코드 (검사, 처치, 약 등)
+     * - 보험 도메인 카테고리로 직접 사용하기에는 부족하며, 추가 매핑 필요
+     */
+    @Column(name = "fee_division_number")
+    private String feeDivisionNumber;
+
+    /**
+     * 급여 여부
+     * - 급여 / 비급여 구분
+     * - 실손 보장 판단의 참고 값으로 사용됨
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "pay_type", nullable = false)
+    private PayType payType;
+
+    /**
+     * 단가 (원)
+     * - 해당 수가의 기본 금액
+     */
+    @Column(name = "unit_price")
+    private Integer unitPrice;
+
+    /**
+     * 상대가치점수 (RVU)
+     * - 수가 계산 시 사용되는 상대 가치
+     */
+    @Column(name = "relative_value_point")
+    private BigDecimal relativeValuePoint;
+
+    /**
+     * 적용 시작일자
+     * - 해당 수가가 유효한 시작 시점
+     */
+    @Column(name = "effective_start_date")
+    private LocalDate effectiveStartDate;
+
+    /**
+     * 수가 유형
+     * - 진료 / 한방 / 약국 구분
+     */
+    @Enumerated(EnumType.STRING)
+    @Column(name = "fee_type", nullable = false)
+    private FeeType feeType;
+
+    /**
+     * 급여 여부 판단
+     *
+     * @return 급여 여부
+     */
+    public boolean isPay() {
+        return this.payType == PayType.PAY;
+    }
+
+    /**
+     * EDI 코드 생성
+     *
+     * @param code 수가 코드
+     * @param treatmentName 한글명
+     * @param feeDivisionNumber 수가 분류 번호
+     * @param payType 급여 여부
+     * @param unitPrice 단가
+     * @param relativeValuePoint 상대가치점수
+     * @param effectiveStartDate 적용 시작일자
+     * @param feeType 수가 유형
+     */
+    public static EdiCode create(
+            String code,
+            String treatmentName,
+            String feeDivisionNumber,
+            PayType payType,
+            Integer unitPrice,
+            BigDecimal relativeValuePoint,
+            LocalDate effectiveStartDate,
+            FeeType feeType
+    ) {
+        return EdiCode.builder()
+                .code(code)
+                .treatmentName(treatmentName)
+                .feeDivisionNumber(feeDivisionNumber)
+                .payType(payType)
+                .unitPrice(unitPrice)
+                .relativeValuePoint(relativeValuePoint)
+                .effectiveStartDate(effectiveStartDate)
+                .feeType(feeType)
+                .build();
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/FeeType.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/FeeType.java
@@ -1,0 +1,18 @@
+package com.silsonfit.silsonfit_api.domain.calculation.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 수가 유형
+ */
+@Getter
+@RequiredArgsConstructor
+public enum FeeType {
+
+    MEDICAL("진료수가"),
+    KOREAN_MEDICAL("한방수가"),
+    PHARMACY("약국수가");
+
+    private final String description;
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/InsuranceGeneration.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/InsuranceGeneration.java
@@ -1,0 +1,20 @@
+package com.silsonfit.silsonfit_api.domain.calculation.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 실손 보험 세대
+ */
+@Getter
+@RequiredArgsConstructor
+public enum InsuranceGeneration {
+
+    FIRST("1세대"),
+    SECOND("2세대"),
+    THIRD("3세대"),
+    FOURTH("4세대"),
+    FIFTH("5세대");
+
+    private final String description;
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/PayType.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/PayType.java
@@ -1,0 +1,17 @@
+package com.silsonfit.silsonfit_api.domain.calculation.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 급여 / 비급여 여부
+ */
+@Getter
+@RequiredArgsConstructor
+public enum PayType {
+
+    PAY("급여"),
+    NON_PAY("비급여");
+
+    private final String description;
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/PurposeType.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/PurposeType.java
@@ -1,0 +1,18 @@
+package com.silsonfit.silsonfit_api.domain.calculation.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 진료 목적
+ */
+@Getter
+@RequiredArgsConstructor
+public enum PurposeType {
+
+    TREATMENT("치료 목적"),
+    CHECKUP("단순 검사"),
+    UNKNOWN("잘 모름");
+
+    private final String description;
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/TreatmentCategory.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/TreatmentCategory.java
@@ -1,0 +1,22 @@
+package com.silsonfit.silsonfit_api.domain.calculation.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 진료 항목
+ */
+@Getter
+@RequiredArgsConstructor
+public enum TreatmentCategory {
+
+    MRI("MRI"),
+    CT("CT"),
+    MANUAL_THERAPY("도수치료"),
+    SHOCKWAVE_THERAPY("체외충격파"),
+    INJECTION("주사"),
+    PHYSICAL_THERAPY("물리치료"),
+    GENERAL_TREATMENT("일반진료");
+
+    private final String description;
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/VisitType.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/VisitType.java
@@ -1,0 +1,18 @@
+package com.silsonfit.silsonfit_api.domain.calculation.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 진료 유형
+ */
+@Getter
+@RequiredArgsConstructor
+public enum VisitType {
+
+    OUTPATIENT("외래"),
+    INPATIENT("입원"),
+    MEDICATION("약제");
+
+    private final String description;
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/GenerationPolicyFactory.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/GenerationPolicyFactory.java
@@ -1,0 +1,33 @@
+package com.silsonfit.silsonfit_api.domain.calculation.policy;
+
+import com.silsonfit.silsonfit_api.domain.calculation.enums.InsuranceGeneration;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * 보험 세대별 계산 Policy Factory
+ *
+ */
+@Component
+@RequiredArgsConstructor
+public class GenerationPolicyFactory {
+
+    private final List<InsuranceGenerationPolicy> policies;
+
+    /**
+     * 보험 세대에 맞는 계산 Policy 반환
+     *
+     * @param generation 보험 세대
+     * @return 해당 세대를 처리할 Policy
+     */
+    public InsuranceGenerationPolicy getPolicy(InsuranceGeneration generation) {
+        return policies.stream()
+                .filter(policy -> policy.supports(generation))
+                .findFirst()
+                .orElseThrow(() ->
+                        new IllegalArgumentException("지원하지 않는 보험 세대입니다: " + generation)
+                );
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/InsuranceGenerationPolicy.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/InsuranceGenerationPolicy.java
@@ -1,0 +1,44 @@
+package com.silsonfit.silsonfit_api.domain.calculation.policy;
+
+import com.silsonfit.silsonfit_api.domain.calculation.enums.InsuranceGeneration;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.PurposeType;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.VisitType;
+import com.silsonfit.silsonfit_api.domain.calculation.vo.CalculationResult;
+
+/**
+ * 실손 보험 세대별 계산 정책 인터페이스
+ * - 1~4세대 실손보험의 계산 공식을 추상화
+ * - CalculationService는 세대별 구현체를 알 필요 없이 이 인터페이스로 계산 수행
+ *
+ */
+public interface InsuranceGenerationPolicy {
+
+    /**
+     * 해당 Policy가 처리 가능한 보험 세대인지 판단
+     *
+     * @param generation 보험 세대
+     * @return 지원 여부
+     */
+    boolean supports(InsuranceGeneration generation);
+
+    /**
+     * 세대별 실손 보험 계산 수행
+     *
+     * @param insuranceId 보험 ID
+     * @param medicalCost 의료비 입력값
+     * @param ediCode EDI 코드
+     * @param visitType 진료 유형
+     * @param treatmentCategory 진료 항목
+     * @param purposeType 진료 목적
+     * @return 계산 결과
+     */
+    CalculationResult calculate(
+            Long insuranceId,
+            Integer medicalCost,
+            String ediCode,
+            VisitType visitType,
+            TreatmentCategory treatmentCategory,
+            PurposeType purposeType
+    );
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/repository/CoverageRuleRepository.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/repository/CoverageRuleRepository.java
@@ -1,0 +1,34 @@
+package com.silsonfit.silsonfit_api.domain.calculation.repository;
+
+import com.silsonfit.silsonfit_api.domain.calculation.entity.CoverageRule;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.PurposeType;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.VisitType;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * 보험별 보장 룰 Repository
+ *
+ */
+public interface CoverageRuleRepository extends JpaRepository<CoverageRule, Long> {
+
+    /**
+     * EDI 코드 기반 보장 룰 조회
+     */
+    Optional<CoverageRule> findByInsuranceIdAndEdiCode(
+            Long insuranceId,
+            String ediCode
+    );
+
+    /**
+     * 진료 유형/항목/목적 기반 보장 룰 조회
+     */
+    Optional<CoverageRule> findByInsuranceIdAndVisitTypeAndTreatmentCategoryAndPurposeType(
+            Long insuranceId,
+            VisitType visitType,
+            TreatmentCategory treatmentCategory,
+            PurposeType purposeType
+    );
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/vo/CalculationResult.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/vo/CalculationResult.java
@@ -1,0 +1,52 @@
+package com.silsonfit.silsonfit_api.domain.calculation.vo;
+
+import lombok.*;
+
+import java.util.List;
+
+/**
+ * 실손 보험 계산 결과 VO
+ */
+@Getter
+@Builder
+@AllArgsConstructor
+@NoArgsConstructor
+public class CalculationResult {
+
+    /** 보장 여부 */
+    private Boolean isCovered;
+
+    /** 예상 환급액 (원 단위) */
+    private Integer refundAmount;
+
+    /** 총 자기부담금 (원 단위) */
+    private Integer deductibleAmount;
+
+    /**
+     * 계산 근거 목록
+     * 예:
+     * - "MRI 항목 보장률 30% 적용"
+     * - "4세대 실손보험 기준 자기부담금 적용"
+     */
+    private List<String> basis;
+
+    /** 면책 또는 주의사항 */
+    private String disclaimer;
+
+    /** 계산 결과 생성 */
+    public static CalculationResult of(
+            Boolean isCovered,
+            Integer refundAmount,
+            Integer deductibleAmount,
+            List<String> basis,
+            String disclaimer
+    ) {
+        return CalculationResult.builder()
+                .isCovered(isCovered)
+                .refundAmount(refundAmount)
+                .deductibleAmount(deductibleAmount)
+                .basis(basis)
+                .disclaimer(disclaimer)
+                .build();
+    }
+}


### PR DESCRIPTION
### 💻 작업 내용

* 실손 보험 계산을 위한 도메인 기반 구조 설계
* CalculationHistory 엔티티 및 진료 관련 enum 정의
* 보험 세대 기반 정책(Policy) 구조 설계 (추후 삭제 예정 -> 구현 방식은 해당 PR에서 자세히 설명하겠습니다.)
* CoverageRule 엔티티 및 Repository 추가
* CalculationRequest / CalculationResponse DTO 정의
* EDI Code 엔티티 및 관련 enum(FeeType, PayType) 추가

### ✨ 리뷰 포인트

* CoverageRule과 EdiCode를 분리한 모델링이 확장성 측면에서 적절한지
* CalculationResult VO 구조가 이후 계산 로직 확장에 충분한지

### 📝 메모

* API 전체를 개발하니 PR이 너무 커져서 분리했습니다. 현재는 도메인 구조와 정책 분리 중심의 초기 설계 단계 PR입니다.
* 아직 계산 로직(Service) 및 API는 포함하지 않은 상태입니다.

### 🎯 관련 이슈

closed #28 