### PR TITLE
feat: 보험 약관 AI 분석 API 구현 및 테스트 코드 추가 #20

### DIFF
--- a/silsonfit-api/build.gradle
+++ b/silsonfit-api/build.gradle
@@ -17,6 +17,10 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+	set('springAiVersion', "1.1.4")
+}
+
 dependencies {
 	// 운영 상태 확인, 헬스 체크, 메트릭 수집용
 	implementation 'org.springframework.boot:spring-boot-starter-actuator'
@@ -51,6 +55,15 @@ dependencies {
 	// 실제 PostgreSQL 연동용 드라이버
 	runtimeOnly 'org.postgresql:postgresql'
 
+	// Spring AI - Ollama (로컬 테스트용)
+	implementation 'org.springframework.ai:spring-ai-starter-model-ollama'
+
+	// Spring AI - Gemini (배포용)
+	implementation 'org.springframework.ai:spring-ai-starter-model-vertex-ai-gemini'
+
+	// PDF 파싱
+	implementation 'org.apache.pdfbox:pdfbox:3.0.2'
+
 	// 테스트 기본 라이브러리
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 
@@ -63,6 +76,13 @@ dependencies {
 
 	// JUnit 플랫폼 실행 지원
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
+}
+
+// Spring AI 의존성 버전 자동 관리
+dependencyManagement {
+	imports {
+		mavenBom "org.springframework.ai:spring-ai-bom:${springAiVersion}"
+	}
 }
 
 tasks.named('test') {

--- a/silsonfit-api/build.gradle
+++ b/silsonfit-api/build.gradle
@@ -55,14 +55,14 @@ dependencies {
 	// 실제 PostgreSQL 연동용 드라이버
 	runtimeOnly 'org.postgresql:postgresql'
 
-	// Spring AI - Ollama (로컬 테스트용)
-	implementation 'org.springframework.ai:spring-ai-starter-model-ollama'
-
-	// Spring AI - Gemini (배포용)
-	implementation 'org.springframework.ai:spring-ai-starter-model-vertex-ai-gemini'
+	// Spring AI - Gemini
+	implementation 'org.springframework.ai:spring-ai-starter-model-google-genai'
 
 	// PDF 파싱
 	implementation 'org.apache.pdfbox:pdfbox:3.0.2'
+
+	// AWS S3
+	implementation 'software.amazon.awssdk:s3:2.25.11'
 
 	// 테스트 기본 라이브러리
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/controller/AnalysisController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/controller/AnalysisController.java
@@ -1,0 +1,98 @@
+package com.silsonfit.silsonfit_api.domain.analysis.controller;
+
+import com.silsonfit.silsonfit_api.domain.analysis.dto.AnalysisRequest;
+import com.silsonfit.silsonfit_api.domain.analysis.dto.AnalysisTaskDTO;
+import com.silsonfit.silsonfit_api.domain.analysis.service.AnalysisService;
+import com.silsonfit.silsonfit_api.domain.analysis.service.SseEmitters;
+import com.silsonfit.silsonfit_api.global.auth.CustomUserDetails;
+import com.silsonfit.silsonfit_api.global.common.ApiResponse;
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.MediaType;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api")
+@Slf4j
+public class AnalysisController {
+
+    private final AnalysisService analysisService;
+    private final SseEmitters sseEmitters;
+
+    /**
+     * 클라이언트와 서버간의 SSE 연결
+     * 연결이 성공하면 프론트에게 clientId를 발송한다.
+     *
+     * @param userDetails 사용자 정보 (비회원은 null)
+     * @return 연결이 유지되는 SseEmitter 객체
+     */
+    @GetMapping(value = "/sse/connect", produces = MediaType.TEXT_EVENT_STREAM_VALUE)
+    public SseEmitter connect(@AuthenticationPrincipal CustomUserDetails userDetails) {
+        // 비회원은 랜덤 UUID 값을 clientId로 사용
+        String clientId = (userDetails != null) ? String.valueOf(userDetails.getUserId())
+                : UUID.randomUUID().toString();
+
+        SseEmitter emitter = sseEmitters.subscribe(clientId);
+
+        // connected 라는 이름으로 프론트쪽에 clientId를 넘겨준다.
+        sseEmitters.send(clientId, "connected", clientId);
+        return emitter;
+    }
+
+    /**
+     * 약관 PDF 파일 또는 내 보험 ID를 받아 비동기 AI 분석
+     *
+     * @param userDetails 사용자 정보 (비회원은 null)
+     * @param request SSE 클라이언트 ID, UserInsuranceId or PDF File
+     */
+    @PostMapping(value = "/analysis", consumes = MediaType.MULTIPART_FORM_DATA_VALUE)
+    public ApiResponse<Void> analysis(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @ModelAttribute AnalysisRequest request) {
+
+        // 요청 유효성 검사
+        if (!request.isValid()) {
+            log.warn("보험 ID나 PDF 파일 중 하나는 필수입니다.");
+            throw new BusinessException(ErrorCode.INVALID_REQUEST);
+        }
+
+        // 회원이면 userId를 채워주고, 비회원이면 null
+        Long userId = (userDetails != null) ? userDetails.getUserId() : null;
+
+        // 파일 여부
+        boolean hasFile = (request.file() != null && !request.file().isEmpty());
+
+        log.info("약관 분석 요청 - userId={}, clientId={}, userInsuranceId={}, hasFile={}",
+                userId, request.clientId(), request.userInsuranceId(),
+                hasFile);
+
+        byte[] fileBytes = null;
+        String contentType = null;
+        String originalFileName = null;
+        if (hasFile) {
+            try {
+                fileBytes = request.file().getBytes();
+                contentType = request.file().getContentType();
+                originalFileName = request.file().getOriginalFilename();
+            } catch (IOException e) {
+                log.error("파일을 읽는 중 오류가 발생했습니다.", e);
+                throw new BusinessException(ErrorCode.FILE_READ_FAILED);
+            }
+        }
+
+        AnalysisTaskDTO analysisTaskDTO = new AnalysisTaskDTO(userId, request.clientId(), request.userInsuranceId(),
+                fileBytes, contentType, originalFileName);
+
+        analysisService.analysis(analysisTaskDTO);
+
+        return ApiResponse.success();
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/controller/AnalysisHistoryController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/controller/AnalysisHistoryController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api")
+@RequestMapping("/api/history/analysis")
 @Slf4j
 public class AnalysisHistoryController {
 
@@ -28,7 +28,7 @@ public class AnalysisHistoryController {
      * @param pageable 페이징 정보
      * @return 분석 이력 리스트
      */
-    @GetMapping("/history/analysis")
+    @GetMapping
     public ApiResponse<Page<AnalysisHistoryListResponse>> getHistories(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                                        @PageableDefault(size = 5) Pageable pageable) {
         Long userId = userDetails.getUserId();
@@ -45,7 +45,7 @@ public class AnalysisHistoryController {
      * @param historyId 분석 이력 ID
      * @return 분석 이력 상세 정보
      */
-    @GetMapping("/history/analysis/{historyId}")
+    @GetMapping("/{historyId}")
     public ApiResponse<AnalysisHistoryDetailResponse> getHistoryDetail(@AuthenticationPrincipal CustomUserDetails userDetails,
                                                                        @PathVariable Long historyId) {
         Long userId = userDetails.getUserId();
@@ -63,7 +63,7 @@ public class AnalysisHistoryController {
      * @param historyId 분석 이력 ID
      * @return 삭제 성공 시 빈 응답 (200)
      */
-    @DeleteMapping("/history/analysis/{historyId}")
+    @DeleteMapping("/{historyId}")
     public ApiResponse<Void> deleteHistory(@AuthenticationPrincipal CustomUserDetails userDetails,
                                         @PathVariable Long historyId) {
         Long userId = userDetails.getUserId();
@@ -73,6 +73,27 @@ public class AnalysisHistoryController {
         analysisHistoryService.deleteHistory(userId, historyId);
 
         log.info("분석 이력 삭제 성공 - userId={}, historyId={}", userId, historyId);
+
+        return ApiResponse.success();
+    }
+
+    /**
+     * 분석 이력 즐겨찾기 (토글방식)
+     *
+     * @param userDetails 로그인한 사용자 정보
+     * @param historyId 분석 이력 ID
+     * @return 삭제 성공 시 빈 응답 (200)
+     */
+    @PatchMapping("/{historyId}")
+    public ApiResponse<Void> toggleFavorite(@AuthenticationPrincipal CustomUserDetails userDetails,
+                                            @PathVariable Long historyId) {
+        Long userId = userDetails.getUserId();
+
+        log.info("이력 즐겨찾기 요청 - userId={}, historyId={}", userId, historyId);
+
+        analysisHistoryService.toggleFavorite(userId, historyId);
+
+        log.info("이력 즐겨찾기 상태 변경 완료 - userId={}, historyId={}", userId, historyId);
 
         return ApiResponse.success();
     }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/dto/AnalysisHistoryCreateCommand.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/dto/AnalysisHistoryCreateCommand.java
@@ -1,0 +1,17 @@
+package com.silsonfit.silsonfit_api.domain.analysis.dto;
+
+import com.silsonfit.silsonfit_api.domain.analysis.vo.AnalysisResult;
+
+// AI 분석결과와 메타데이터를 묶어 분석이력 엔티티를 생성할 때 넘겨주는 dto
+public record AnalysisHistoryCreateCommand(
+        Long userId,
+        String originalFileName,
+        String pdfFileUrl,
+        String companyName,
+        String productName,
+        String contractType,
+        String generation,
+        String coverageStructure,
+        String cautionPoint,
+        AnalysisResult aiSummary
+) {}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/dto/AnalysisRequest.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/dto/AnalysisRequest.java
@@ -1,0 +1,13 @@
+package com.silsonfit.silsonfit_api.domain.analysis.dto;
+
+import org.springframework.web.multipart.MultipartFile;
+
+public record AnalysisRequest(
+        String clientId,        // 프론트에서 넘겨주는 아이디 (sse Map 의 키 값)
+        Long userInsuranceId,   // 내 보험 아이디 ( 보험을 선택하지 않으면 null )
+        MultipartFile file      // pdf 파일 ( 보험을 선택했다면 null )
+) {
+    public boolean isValid() {
+        return userInsuranceId != null || (file != null && !file.isEmpty());
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/dto/AnalysisTaskDTO.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/dto/AnalysisTaskDTO.java
@@ -1,0 +1,11 @@
+package com.silsonfit.silsonfit_api.domain.analysis.dto;
+
+public record AnalysisTaskDTO(
+        Long userId,
+        String clientId,
+        Long userInsuranceId,
+        byte[] fileBytes,
+        String contentType,
+        String originalFileName
+) {
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/entity/AnalysisHistory.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/entity/AnalysisHistory.java
@@ -1,5 +1,6 @@
 package com.silsonfit.silsonfit_api.domain.analysis.entity;
 
+import com.silsonfit.silsonfit_api.domain.analysis.dto.AnalysisHistoryCreateCommand;
 import com.silsonfit.silsonfit_api.domain.analysis.vo.AnalysisResult;
 import com.silsonfit.silsonfit_api.global.common.BaseCreatedTimeEntity;
 import jakarta.persistence.*;
@@ -63,21 +64,18 @@ public class AnalysisHistory extends BaseCreatedTimeEntity {
     private Boolean isFavorite = false; // 즐겨찾기
 
     // 생성자 - 정적 팩토리 메서드 패턴 + 빌더 사용
-    public static AnalysisHistory create(Long userId, String originalFileName, String pdfFileUrl,
-                                         String companyName, String productName, String contractType,
-                                         String generation, String coverageStructure, String cautionPoint,
-                                         AnalysisResult aiSummary) {
+    public static AnalysisHistory create(AnalysisHistoryCreateCommand command) {
         return AnalysisHistory.builder()
-                .userId(userId)
-                .originalFileName(originalFileName)
-                .pdfFileUrl(pdfFileUrl)
-                .companyName(companyName)
-                .productName(productName)
-                .contractType(contractType)
-                .generation(generation)
-                .coverageStructure(coverageStructure)
-                .cautionPoint(cautionPoint)
-                .aiSummary(aiSummary)
+                .userId(command.userId())
+                .originalFileName(command.originalFileName())
+                .pdfFileUrl(command.pdfFileUrl())
+                .companyName(command.companyName())
+                .productName(command.productName())
+                .contractType(command.contractType())
+                .generation(command.generation())
+                .coverageStructure(command.coverageStructure())
+                .cautionPoint(command.cautionPoint())
+                .aiSummary(command.aiSummary())
                 .build();
     }
 

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/service/AiAnalysisService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/service/AiAnalysisService.java
@@ -1,0 +1,68 @@
+package com.silsonfit.silsonfit_api.domain.analysis.service;
+
+import com.silsonfit.silsonfit_api.domain.analysis.vo.AnalysisResult;
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.ai.converter.BeanOutputConverter;
+import org.springframework.stereotype.Service;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class AiAnalysisService {
+
+    private final ChatClient chatClient;
+
+    /**
+     * 추출된 약관 PDF 텍스트를 AI 모델에 전송하여 분석 결과를 반환한다.
+     *
+     * @param pdfText PDF 파일에서 추출한 원본 약관 텍스트
+     * @return AI가 분석 후 요약한 정보를 담은 VO
+     */
+    public AnalysisResult analysisPrompt(String pdfText) {
+        log.info("AI 약관 분석 start - length={}", pdfText.length());
+
+        BeanOutputConverter<AnalysisResult> outputConverter = new BeanOutputConverter<>(AnalysisResult.class);
+        String format = outputConverter.getFormat();
+
+        String prompt = """
+                너는 10년 차 수석 손해사정사이자 약관 분석 전문가야.
+                제공된 보험 약관 텍스트를 분석해서, 사용자가 웹의 한 화면에서 빠르게 읽을 수 있도록 핵심만 압축한 요약 리포트를 만들어줘.
+                
+                [분석 및 작성 가이드]
+                1. 분량 압축: 약관 내용이 방대하더라도, 각 항목의 배열(Array)에 들어가는 문장은 핵심만 추려서 최대한 짧고 간결하게 1~2줄 이내로 작성해. 불필요한 부연 설명은 모두 제거해.
+                2. 문체(말투) 변경: '~합니다', '~습니다', '~입니다' 등의 길고 격식 있는 서술어는 절대 사용하지마. 대신 명사로 문장을 끝맺거나, '~함', '~됨', '~임'으로 끝나는 [개조식 문제]를 엄격하게 적용해.
+                3. 예시 활용 원칙: 제공된 JSON 포맷의 예시 문장들은 '이런 식의 짧은 문체를 사용하라'는 참고용이야. 예시 내용을 절대 그대로 복사하지 말고, 반드시 [약관 원본 텍스트]의 팩트에 기반해서 새롭게 요약해.
+                4. 표나 리스트가 텍스트로 평면화되어 있으니 문맥을 잘 파악해서 알맞은 항목에 매핑해.
+                5. 약관에 해당 내용이 전혀 없다면 임의로 지어내지 말고 빈 배열([])이나 "내용 없음"으로 처리해.
+                
+                [주의 사항]
+                - 반드시 아래에 제공된 JSON 스키마 포맷에 완벽하게 일치하는 JSON만 출력해.
+                - JSON 외의 어떠한 부연 설명(```json 등)도 포함하지 마.
+                
+                [출력 포맷]
+                {format}
+                
+                [약관 원본 텍스트]
+                {text}
+                """;
+
+        try {
+            String aiResponse = chatClient.prompt()
+                    .user(u -> u.text(prompt)
+                            .param("format", format)
+                            .param("text", pdfText))
+                    .call()
+                    .content();
+
+            log.info("AI 약관 분석 성공 - JSON 응답 반환");
+            return outputConverter.convert(aiResponse);
+        } catch (Exception e) {
+            log.error("AI 분석 중 예외 발생 - {}", e.getMessage(), e);
+            throw new BusinessException(ErrorCode.AI_ANALYSIS_FAILED);
+        }
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/service/AnalysisHistoryService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/service/AnalysisHistoryService.java
@@ -4,6 +4,7 @@ import com.silsonfit.silsonfit_api.domain.analysis.dto.AnalysisHistoryDetailResp
 import com.silsonfit.silsonfit_api.domain.analysis.dto.AnalysisHistoryListResponse;
 import com.silsonfit.silsonfit_api.domain.analysis.entity.AnalysisHistory;
 import com.silsonfit.silsonfit_api.domain.analysis.repository.AnalysisHistoryRepository;
+import com.silsonfit.silsonfit_api.global.aws.S3Service;
 import com.silsonfit.silsonfit_api.global.error.BusinessException;
 import com.silsonfit.silsonfit_api.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -20,6 +21,7 @@ import org.springframework.transaction.annotation.Transactional;
 public class AnalysisHistoryService {
 
     private final AnalysisHistoryRepository analysisHistoryRepository;
+    private final S3Service s3Service;
 
     /**
      * 분석 이력 리스트 조회
@@ -68,8 +70,27 @@ public class AnalysisHistoryService {
             throw new BusinessException(ErrorCode.HISTORY_ACCESS_DENIED);
         }
 
-        // TODO: S3 파일 삭제 로직 추가 예정
+        s3Service.delete(history.getPdfFileUrl());
 
         analysisHistoryRepository.delete(history);
+    }
+
+    /**
+     * 분석 이력 즐겨찾기 (토글)
+     *
+     * @param userId 사용자 ID
+     * @param historyId 즐겨찾기를 적용할 이력 ID
+     */
+    @Transactional
+    public void toggleFavorite(Long userId, Long historyId) {
+        AnalysisHistory history = analysisHistoryRepository.findById(historyId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.HISTORY_NOT_FOUND));
+
+        if (!history.getUserId().equals(userId)) {
+            log.warn("즐겨찾기 권한이 없습니다. - userId={}, historyId={}", userId, historyId);
+            throw new BusinessException(ErrorCode.HISTORY_ACCESS_DENIED);
+        }
+
+        history.toggleFavorite();
     }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/service/AnalysisService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/service/AnalysisService.java
@@ -1,0 +1,127 @@
+package com.silsonfit.silsonfit_api.domain.analysis.service;
+
+import com.silsonfit.silsonfit_api.domain.analysis.dto.AnalysisHistoryCreateCommand;
+import com.silsonfit.silsonfit_api.domain.analysis.dto.AnalysisHistoryDetailResponse;
+import com.silsonfit.silsonfit_api.domain.analysis.dto.AnalysisTaskDTO;
+import com.silsonfit.silsonfit_api.domain.analysis.entity.AnalysisHistory;
+import com.silsonfit.silsonfit_api.domain.analysis.repository.AnalysisHistoryRepository;
+import com.silsonfit.silsonfit_api.domain.analysis.vo.AnalysisResult;
+import com.silsonfit.silsonfit_api.global.aws.S3Service;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class AnalysisService {
+
+    private final AnalysisHistoryRepository analysisHistoryRepository;
+    private final SseEmitters sseEmitters;
+    private final PdfService pdfService;
+    private final AiAnalysisService aiAnalysisService;
+    private final S3Service s3UploadService;
+
+    /**
+     * 사용자가 요청한 보험 약관 PDF 파일을 비동기 스레드에서 분석 (@Async)
+     *
+     * @param dto userId, clientId, userInsuranceId, 파일정보가 있는 dto
+     */
+    @Async("taskExecutor")
+    public void analysis(AnalysisTaskDTO dto) {
+        log.info("약관 분석 Service start - userId={}", dto.userId());
+
+        // UserInsurance userInsurance = null;
+        String pdfFileUrl;
+        String originalFileName;
+        String extractedText;
+
+        try {
+            // 1. 내 보험을 선택해서 분석 할 경우
+            if (dto.userInsuranceId() != null) {
+                log.info("내 보험 선택 후 약관 분석 - userInsuranceId={}", dto.userInsuranceId());
+
+                // TODO: 보험 관련 도메인 추가되면 주석 해제 예정
+                // 1. 내 보험 DB 에서 내 보험 엔티티를 조회, S3 URL 을 가져온다.
+            /*
+                userInsurance = UserInsuranceService.getUserInsurance(userInsuranceId);
+                Insurance insurance = userInsurance.getInsurance();
+                originalFileName = insurance.getOriginalFileName();
+                pdfFileUrl = insurance.getPdfFileUrl();
+             */
+                originalFileName = "";
+                pdfFileUrl = "";
+
+                // 2. PDF 텍스트 추출
+                extractedText = pdfService.extractText(pdfFileUrl);
+            }
+            // 2. 내 컴퓨터에서 PDF 파일을 업로드하여 분석할 경우
+            else {
+                log.info("내 컴퓨터에서 PDF 파일을 업로드 하여 분석 - fileName={}", dto.originalFileName());
+                originalFileName = dto.originalFileName();
+
+                // 1. 파일을 S3에 업로드 후 URL 반환
+                pdfFileUrl = s3UploadService.upload(dto.fileBytes(), dto.originalFileName(), dto.contentType());
+
+                // 2. PDF 파일 텍스트 추출
+                extractedText = pdfService.extractText(dto.fileBytes());
+            }
+
+            // 3. AI 분석
+            AnalysisResult result = aiAnalysisService.analysisPrompt(extractedText);
+
+            // 4. 회원이면 DB에 저장
+            if (dto.userId() != null) {
+                // 스냅샷 정보를 보험 엔티티에서 꺼내어 넣어준다.
+                AnalysisHistoryCreateCommand command = null;
+                if (dto.userInsuranceId() != null) {
+                    // TODO: 보험 관련 도메인 추가되면 주석 해제 예정
+                    // Insurance insurance = userInsurance.getInsurance();
+                /*
+                    command = new AnalysisHistoryCreateCommand(userId, originalFileName, pdfFileUrl,
+                        insurance.getCompanyName(), insurance.getProductName(), insurance.getContractType(),
+                        insurance.getGeneration(), insurance.getCoverageStructure(), insurance.getCautionPoint(), result);
+                 */
+                }
+                // 스냅샷 정보를 AI 분석결과에서 꺼내어 넣어준다.
+                else {
+                    command = new AnalysisHistoryCreateCommand(dto.userId(), originalFileName, pdfFileUrl,
+                            result.metadata().companyName(), result.metadata().productName(), result.metadata().contractType(),
+                            result.metadata().generation(), result.metadata().coverageStructure(), result.metadata().cautionPoint(), result);
+                }
+                // DB에 저장
+                saveHistory(command);
+                log.info("분석 이력 저장 성공 - userId={}", command.userId());
+            }
+
+            // 5. 프론트에 응답보낼 dto 조립
+            AnalysisHistoryDetailResponse response =
+                    AnalysisHistoryDetailResponse.of(result, originalFileName, pdfFileUrl);
+
+            // 6. 프론트에 sse 전송
+            sseEmitters.send(dto.clientId(), "analysisComplete", response);
+            sseEmitters.complete(dto.clientId());
+        } catch (Exception e) {
+            log.error("약관 분석 중 오류 발생 - clientId={}", dto.clientId(), e);
+
+            // 에러 발생 시 프론트가 무한 대기 하지 않도록 에러 이벤트를 전송해준다.
+            sseEmitters.send(dto.clientId(), "error", "약관 분석 중 오류 발생");
+            sseEmitters.complete(dto.clientId());
+        }
+        log.info("약관 분석 Service 종료");
+    }
+
+    /**
+     * AI 분석 후, 회원이라면 분석 이력을 DB에 저장한다.
+     * AI 분석은 비동기처리를 하기때문에 DB 저장 로직만 따로 빼서 트랜잭션을 적용함.
+     *
+     * @param command DB에 저장할 데이터가 담긴 DTO
+     */
+    @Transactional
+    public void saveHistory(AnalysisHistoryCreateCommand command) {
+        AnalysisHistory history = AnalysisHistory.create(command);
+        analysisHistoryRepository.save(history);
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/service/PdfService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/service/PdfService.java
@@ -1,0 +1,70 @@
+package com.silsonfit.silsonfit_api.domain.analysis.service;
+
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
+import org.apache.pdfbox.Loader;
+import org.apache.pdfbox.pdmodel.PDDocument;
+import org.apache.pdfbox.text.PDFTextStripper;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+
+@Service
+@Slf4j
+public class PdfService {
+
+    /**
+     * PDF 파일의 텍스트를 추출하여 반환
+     *
+     * @param fileBytes PDF 파일의 byte 배열
+     * @return 추출된 전체 텍스트
+     */
+    public String extractText(byte[] fileBytes) {
+        log.info("[FILE] 텍스트 추출 start");
+
+        // try-with-resources 구문을 이용하여 finally 없이 자동으로 자원 해제 처리
+        try (PDDocument document = Loader.loadPDF(fileBytes)) {
+
+            // PDF 를 추출하기 위한 객체 생성
+            PDFTextStripper stripper = new PDFTextStripper();
+
+            String extractedText = stripper.getText(document);
+
+            log.info("[FILE] 텍스트 추출 완료 - length={}", extractedText.length());
+            return extractedText;
+
+        } catch (IOException e) {
+            log.error("[FILE] PDF 텍스트 추출 실패 - {}", e.getMessage(), e);
+            throw new BusinessException(ErrorCode.PDF_PARSING_ERROR);
+        }
+    }
+
+    /**
+     * S3 URL 의 파일을 열어 텍스트 추출
+     *
+     * @param pdfFileUrl PDF 가 저장되어있는 URL
+     * @return 추출된 전체 텍스트
+     */
+    // S3에서 가져온 URL 로 PDF 를 가져와 텍스트 추출
+    public String extractText(String pdfFileUrl) {
+        log.info("[URL] 텍스트 추출 start");
+        // URL 에서 직접 InputStream 을 열어 PDFBox 에 넘겨준다.
+        try (InputStream in = new URL(pdfFileUrl).openStream();
+             PDDocument document = Loader.loadPDF(in.readAllBytes())) {
+
+            PDFTextStripper stripper = new PDFTextStripper();
+
+            String extractedText = stripper.getText(document);
+
+            log.info("[URL] 텍스트 추출 완료 - length={}", extractedText.length());
+            return extractedText;
+        } catch (IOException e) {
+            log.error("[URL] PDF 텍스트 추출 실패 - {}", e.getMessage(), e);
+            throw new BusinessException(ErrorCode.PDF_PARSING_ERROR);
+        }
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/service/SseEmitters.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/service/SseEmitters.java
@@ -1,0 +1,77 @@
+package com.silsonfit.silsonfit_api.domain.analysis.service;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.web.servlet.mvc.method.annotation.SseEmitter;
+
+import java.io.IOException;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+@Service
+@Slf4j
+public class SseEmitters {
+
+    // 여러 클라이언트가 동시에 분석하기를 눌렀을 때 비동기 처리를 하기 때문에
+    // 여러 스레드에서 동시에 접근한다. 그래서 ConcurrentHashMap 을 사용해야한다.
+    private final Map<String, SseEmitter> emitters = new ConcurrentHashMap<>();
+
+    /**
+     * 클라이언트의 SSE 연결을 생성, Map 에 저장한다.
+     * 연결 정상 종료, 타임 아웃 시 콜백 설정 포함
+     *
+     * @param clientId 클라이언트 ID (userID 또는 UUID)
+     */
+    public SseEmitter subscribe(String clientId) {
+        SseEmitter sseEmitter = new SseEmitter(60L * 5 * 1000); // 5분 타임아웃
+        emitters.put(clientId, sseEmitter);
+        log.info("sse 연결 성공 - clientId={}", clientId);
+
+        // 콜백 설정
+        sseEmitter.onCompletion(()->{
+            log.info("sse 연결 정상 종료 - clientId={}", clientId);
+            emitters.remove(clientId);
+        });
+        sseEmitter.onTimeout(()->{
+            log.info("sse 연결 타임아웃 - clientId={}", clientId);
+            emitters.remove(clientId);
+        });
+        return sseEmitter;
+    }
+
+    /**
+     * 특정 클라이언트에게 실시간 데이터 전송
+     *
+     * @param clientId 클라이언트 ID (userID 또는 UUID)
+     * @param name 프론트에서 수신할 데이터의 이름
+     * @param data 전송할 데이터 객체
+     */
+    public void send(String clientId, String name, Object data) {
+        SseEmitter sseEmitter = emitters.get(clientId);
+        if (sseEmitter != null) {
+            try {
+                sseEmitter.send(SseEmitter.event()
+                        .name(name)
+                        .data(data));
+            } catch (IOException e) {
+                log.error("SSE 데이터 전송 중 에러 - clientId={}", clientId);
+                emitters.remove(clientId);
+            }
+        } else {
+            log.info("클라이언트 아이디에 해당하는 SSE 연결이 존재하지 않습니다. - clientId={}", clientId);
+        }
+    }
+
+    /**
+     * SSE 연결을 명시적으로 종료
+     *
+     * @param clientId 클라이언트 ID (userID 또는 UUID)
+     */
+    public void complete(String clientId) {
+        SseEmitter sseEmitter = emitters.get(clientId);
+        if (sseEmitter != null) {
+            sseEmitter.complete();
+            emitters.remove(clientId);
+        }
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/vo/AnalysisResult.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/vo/AnalysisResult.java
@@ -1,9 +1,11 @@
 package com.silsonfit.silsonfit_api.domain.analysis.vo;
 
+import com.fasterxml.jackson.annotation.JsonPropertyDescription;
+
 import java.util.List;
 
 /**
- * AI API 의 응답을 받을 수 있는 DTO
+ * AI API 의 응답을 받을 수 있는 VO
  */
 public record AnalysisResult(
         Metadata metadata,
@@ -16,9 +18,13 @@ public record AnalysisResult(
     public record Metadata(
             String companyName,         // 보험사
             String productName,         // 약관 이름
+            @JsonPropertyDescription("계약 유형. 제시된 예시 중 반드시 1개만 단일 키워드로 선택 (예: 개인실손, 단체실손, 전환용, 재개용)")
             String contractType,        // 계약 유형
+            @JsonPropertyDescription("실손의료보험의 세대. 제시된 예시 중 반드시 1개만 단일 키워드로 선택 (예: 1세대, 2세대, 3세대, 4세대, 5세대, 세대확인필요)")
             String generation,          // 세대
+            @JsonPropertyDescription("보장 구조. 제시된 예시 중 반드시 1개만 단일 키워드로 선택 (예: 급여중심, 급여+비급여, 3대비급여, 비급여포함, 특약포함, 입.통원포함, 통원중심, 기본형중심, 처방조제포함")
             String coverageStructure,   // 보장 구조
+            @JsonPropertyDescription("주의 포인트. 제시된 예시 중 반드시 1개만 단일 키워드로 선택 (예: 자기부담높음, 갱신형, 재가입형, 보장제한많음, 청구유의, 면책확인, 3대비급여주의, 상급병실주의")
             String cautionPoint         // 주의 포인트
     ) {}
 
@@ -26,18 +32,28 @@ public record AnalysisResult(
      * 보험 상세 분석 결과
      */
     public record SummaryContent(
+            @JsonPropertyDescription("AI 핵심 요약 (예: '급여(건강보험 적용 항목) 중심, '비급여는 특약 가입 시 보장', '1년 갱신형', '보장내용 변경주기 최대 5년')")
             List<String> coreSummary,           // AI 핵심 요약
+            @JsonPropertyDescription("보장 구조 객체 (기본 보장, 추가 보장(특약 가입 시), 보장되지 않는 항목)")
             CoverageDetails coverageDetails,    // 보장 구조
+            @JsonPropertyDescription("보장 범위 (예: '입원: 급여 시 약 80% 보장, 비급여 시 약 70% 보장', '통원: 최소 1~3만원 공제 후 지급, 또는 20~30%의 공제 중 더 큰 금액 차감')")
             List<String> coverageScope,         // 보장 범위
+            @JsonPropertyDescription("제한 조건 (예: '통원 1회당 금액 제한', '통원, 3대 비급여 연간 횟수·금액 한도 (예: 도수치료, 주사 등)')")
             List<String> limitations,           // 제한 조건
+            @JsonPropertyDescription("갱신 및 재가입 조건 (예: '1년 갱신형', '갱신 시 나이 증가나 손해율 등에 따라 보험료 인상 가능', '보장내용 변경주기 최대 5년', '비급여 특약은 이용량에 따라 보험료 차등제 적용')")
             List<String> renewalTerms,          // 갱신, 재가입
+            @JsonPropertyDescription("청구 방법 (예: '서류 접수 후 3영업일 내 지급 (기본)', '초가 조사 필요 시 최대 30영업일 소요')")
             List<String> claimMethod,           // 청구 방법
+            @JsonPropertyDescription("해지 및 환급 안내 (예: '1년 단기 순수보장성, 해약환급금이 발생하지 않음', '보장 목적의 소멸성 보험')")
             List<String> cancellationAndRefund  // 해지, 환급
     ) {}
 
     public record CoverageDetails(
+            @JsonPropertyDescription("기본 보장 항목 (예: '급여 입원비', '급여 통원 치료비', '급여 약값')")
             List<String> basicCoverages,    // 기본 보장
+            @JsonPropertyDescription("추가 보장 및 특약 가입 시 항목 (예: '비급여 치료비', '3대 비급여(도수치료·체외충격파·증식치료 / 주사료 / MRI·MRA)의 경우 별도 한도, 조건 적용')")
             List<String> specialCoverages,  // 추가 보장 (특약 가입 시)
+            @JsonPropertyDescription("보장되지 않는 항목 및 면책 조항 (예: '임신·출산, 건강검진, 예방접종, 일부 치과·한방 비급여, 자동차/산재보험 처리 의료비, 해외 의료기관 치료비 등')")
             List<String> exclusions         // 보장되지 않는 항목
     ) {
     }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/aws/S3Service.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/aws/S3Service.java
@@ -1,0 +1,95 @@
+package com.silsonfit.silsonfit_api.global.aws;
+
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Service;
+import org.springframework.web.multipart.MultipartFile;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.DeleteObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+
+import java.io.IOException;
+import java.util.UUID;
+
+@Service
+@RequiredArgsConstructor
+@Slf4j
+public class S3Service {
+
+    private final S3Client s3Client;
+
+    @Value("${aws.s3.bucket}")
+    private String bucket;
+
+    @Value("${aws.s3.region}")
+    private String region;
+
+    /**
+     * PDF 파일을 받아 S3 버킷에 업로드 후 URL 반환
+     *
+     * @param fileBytes PDF 파일의 byte 배열
+     * @param originalFileName PDF 파일의 원본파일명
+     * @param contentType PDF 파일의 contentType
+     * @return S3 URL
+     */
+    public String upload(byte[] fileBytes, String originalFileName, String contentType) {
+        // 파일명 중복 방지를 위한 UUID 추가
+        String uniqueFileName = UUID.randomUUID() + "_" + originalFileName;
+
+        try {
+            // S3에 올릴 요청 객체 생성 - PutObjectRequest
+            PutObjectRequest putObjectRequest = PutObjectRequest.builder()
+                    .bucket(bucket)
+                    .key(uniqueFileName)
+                    .contentDisposition(contentType) // "application/pdf"
+                    .build();
+
+            // 실제 파일 업로드 실행
+            s3Client.putObject(putObjectRequest,
+                    RequestBody.fromBytes(fileBytes));
+
+            log.info("S3 파일 업로드 성공 - fileName={}", uniqueFileName);
+
+            // 업로드된 파일의 S3 URL 생성 및 반환
+            return getS3FileUrl(uniqueFileName);
+        } catch (Exception e) {
+            log.error("S3 업로드 중 오류 발생", e);
+            throw new BusinessException(ErrorCode.FILE_UPLOAD_FAILED);
+        }
+    }
+
+    /**
+     * S3 URL 기반으로 해당 파일을 버킷에서 삭제한다.
+     *
+     * @param pdfFileUrl S3 전체 URL
+     */
+    public void delete(String pdfFileUrl) {
+        // URL 에서 파일명만 추출 (S3의 키가 됨)
+        String key = extractKeyFromUrl(pdfFileUrl);
+
+        // 삭제 요청 객체 생성 - DeleteObjectRequest
+        DeleteObjectRequest deleteObjectRequest = DeleteObjectRequest.builder()
+                .bucket(bucket)
+                .key(key)
+                .build();
+
+        // S3 파일 삭제
+        s3Client.deleteObject(deleteObjectRequest);
+
+        log.info("S3 파일 삭제 성공 - key={}", key);
+    }
+
+    private String extractKeyFromUrl(String pdfFileUrl) {
+        int lastIndexOf = pdfFileUrl.lastIndexOf("/");
+        return pdfFileUrl.substring(lastIndexOf + 1);
+    }
+
+    private String getS3FileUrl(String fileName) {
+        return String.format("https://%s.s3.%s.amazonaws.com/%s",
+                bucket, region, fileName);
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/AiConfig.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/AiConfig.java
@@ -1,0 +1,15 @@
+package com.silsonfit.silsonfit_api.global.config;
+
+import org.springframework.ai.chat.client.ChatClient;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class AiConfig {
+
+    @Bean
+    public ChatClient chatClient(ChatClient.Builder builder) {
+        // 스프링이 자동 제공하는 Builder 를 받아, 기본 ChatClient 를 Bean 으로 등록
+        return builder.build();
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/AsyncConfig.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/AsyncConfig.java
@@ -1,0 +1,34 @@
+package com.silsonfit.silsonfit_api.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.scheduling.annotation.EnableAsync;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+
+import java.util.concurrent.Executor;
+
+@Configuration
+@EnableAsync
+public class AsyncConfig {
+
+    @Bean(name = "taskExecutor")
+    public Executor taskExecutor() {
+        ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+
+        // 항상 대기하는 스레드 개수
+        executor.setCorePoolSize(5);
+
+        // 대기열 큐 사이즈
+        executor.setQueueCapacity(50);
+
+        //최대 스레드 수 ( 대기열 큐마저 꽉 찼을 때 스레드를 늘린다 )
+        executor.setMaxPoolSize(20);
+
+        // 스레드 이름 접두사
+        executor.setThreadNamePrefix("Silsonfit-");
+
+        // 설정 적용 후 초기화
+        executor.initialize();
+        return executor;
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/S3Config.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/S3Config.java
@@ -1,0 +1,43 @@
+package com.silsonfit.silsonfit_api.global.config;
+
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import software.amazon.awssdk.auth.credentials.AwsBasicCredentials;
+import software.amazon.awssdk.auth.credentials.StaticCredentialsProvider;
+import software.amazon.awssdk.regions.Region;
+import software.amazon.awssdk.services.s3.S3Client;
+
+/**
+ * AWS S3 클라이언트 설정 클래스
+ */
+@Configuration
+public class S3Config {
+
+    @Value("${aws.s3.credentials.access-key}")
+    private String accessKey;
+
+    @Value("${aws.s3.credentials.secret-key}")
+    private String secretKey;
+
+    @Value("${aws.s3.region}")
+    private String region;
+
+    /**
+     * S3Client 빈 등록
+     * AWS SDK v2 사용
+     *
+     * @return
+     */
+    @Bean
+    public S3Client s3Client() {
+        // AccessKey, SecretKey 기반 인증 객체 생성
+        AwsBasicCredentials credentials = AwsBasicCredentials.create(accessKey, secretKey);
+
+        // S3Client 생성 및 반환
+        return S3Client.builder()
+                .region(Region.of(region)) // 리전 설정
+                .credentialsProvider(StaticCredentialsProvider.create(credentials)) // 인증 정보 설정
+                .build();
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/SecurityConfig.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/SecurityConfig.java
@@ -63,8 +63,8 @@ public class SecurityConfig {
                                 "/v3/api-docs/**",
                                 "/actuator/health",
                                 "/actuator/info",
-                                "api/sse/connect",
-                                "api/analysis"
+                                "/api/sse/connect",
+                                "/api/analysis"
                         ).permitAll()
                         .anyRequest().authenticated()
                 );

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/SecurityConfig.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/SecurityConfig.java
@@ -61,7 +61,9 @@ public class SecurityConfig {
                                 "/swagger-ui.html",
                                 "/v3/api-docs/**",
                                 "/actuator/health",
-                                "/actuator/info"
+                                "/actuator/info",
+                                "api/sse/connect",
+                                "api/analysis"
                         ).permitAll()
                         .anyRequest().authenticated()
                 );

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
@@ -5,7 +5,7 @@ import lombok.Getter;
 
 /**
  * 도메인별 에러 코드 정의
- *
+ * <p>
  * 각 담당자는 자기 도메인 영역에만 에러 코드를 추가한다.
  */
 @Getter
@@ -29,8 +29,16 @@ public enum ErrorCode {
     DEACTIVATED_USER(403, "탈퇴한 사용자입니다."),
 
     // ── Analysis ──
+    INVALID_REQUEST(400,"보험 ID나 약관 PDF 파일 중 하나는 필수 입니다."),
     HISTORY_NOT_FOUND(404, "해당 분석 이력을 찾을 수 없습니다."),
     HISTORY_ACCESS_DENIED(403, "해당 분석 이력에 대한 접근 권한이 없습니다."),
+    PDF_PARSING_ERROR(500, "PDF 파일에서 텍스트를 추출하는데 실패했습니다."),
+    AI_ANALYSIS_FAILED(500, "AI 약관 분석 처리 중 오류가 발생했습니다"),
+
+    // ── File ──
+    FILE_READ_FAILED(500,"파일을 읽는 중 오류가 발생했습니다."),
+    FILE_UPLOAD_FAILED(500, "파일을 업로드하는 중 오류가 발생했습니다."),
+    FILE_DELETE_FAILED(500, "파일을 삭제하는 중 오류가 발생했습니다."),
 
     // ── Insurance ──
 

--- a/silsonfit-api/src/main/resources/application-dev.yml
+++ b/silsonfit-api/src/main/resources/application-dev.yml
@@ -22,9 +22,28 @@ spring:
       hibernate:
         format_sql: true
 
+  ai:
+    retry:
+      max-attempts: 1 # 실패 시 재시도 횟수 제한
+    google:
+      genai:
+        api-key: ${GEMINI_API_KEY:dummy}
+        chat:
+          options:
+            model: gemini-2.5-flash
+            temperature: 0.1
+
 jwt:
   # 로컬 개발용 공유 secret. HS256 기준 최소 32자 필요.
   secret: silsonfit-dev-secret-for-local-development-only-32chars
+
+aws:
+  s3:
+    credentials:
+      access-key: ${AWS_S3_ACCESS_KEY:dummy}
+      secret-key: ${AWS_S3_SECRET_KEY:dummy}
+    region: ap-northeast-2
+    bucket: silsonfit-bucket-594754931983-ap-northeast-2-an
 
 management:
   endpoint:

--- a/silsonfit-api/src/main/resources/application-prod.yml
+++ b/silsonfit-api/src/main/resources/application-prod.yml
@@ -10,8 +10,27 @@ spring:
       ddl-auto: validate
     show-sql: false
 
+  ai:
+    retry:
+      max-attempts: 1 # 실패 시 재시도 횟수 제한
+    google:
+      genai:
+        api-key: ${GEMINI_API_KEY}
+        chat:
+          options:
+            model: gemini-2.5-flash
+            temperature: 0.1
+
 jwt:
   secret: ${JWT_SECRET}
+
+aws:
+  s3:
+    credentials:
+      access-key: ${AWS_S3_ACCESS_KEY}
+      secret-key: ${AWS_S3_SECRET_KEY}
+    region: ap-northeast-2
+    bucket: silsonfit-bucket-594754931983-ap-northeast-2-an
 
 management:
   endpoint:

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/analysis/service/AiAnalysisIntegrationTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/analysis/service/AiAnalysisIntegrationTest.java
@@ -1,0 +1,46 @@
+package com.silsonfit.silsonfit_api.domain.analysis.service;
+
+import com.silsonfit.silsonfit_api.domain.analysis.vo.AnalysisResult;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+@SpringBootTest
+public class AiAnalysisIntegrationTest {
+
+    @Autowired
+    AiAnalysisService aiAnalysisService;
+
+    @Autowired
+    PdfService pdfService;
+
+    @Test
+    void PDF_파싱후_AI_분석_통합테스트() throws IOException {
+        File pdfFile = new File("C:\\Java\\무배당 메리츠 실손의료비보험1810약관.pdf");
+
+        MockMultipartFile mockFile = new MockMultipartFile(
+                "file", pdfFile.getName(), "application/pdf", Files.readAllBytes(pdfFile.toPath()));
+
+        // pdf 에서 텍스트 추출
+        System.out.println("PDF 텍스트 추출중");
+        String extractText = pdfService.extractText(mockFile.getBytes());
+        System.out.println("추출 완료 - 텍스트 길이 = " + extractText.length());
+
+        // ai 분석
+        System.out.println("AI 분석 start");
+        long startTime = System.currentTimeMillis();
+        AnalysisResult result = aiAnalysisService.analysisPrompt(extractText);
+        long endTime = System.currentTimeMillis();
+
+        System.out.println("분석완료 - 소요시간 : " + (endTime - startTime) + "ms");
+
+        System.out.println("=================[AI 분석결과]===========================");
+        System.out.println(result.toString());
+        System.out.println("=========================================================");
+    }
+}

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/analysis/service/AiAnalysisServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/analysis/service/AiAnalysisServiceTest.java
@@ -1,0 +1,48 @@
+package com.silsonfit.silsonfit_api.domain.analysis.service;
+
+import com.silsonfit.silsonfit_api.domain.analysis.vo.AnalysisResult;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+@SpringBootTest
+class AiAnalysisServiceTest {
+
+    @Autowired
+    AiAnalysisService aiAnalysisService;
+
+    @Test
+    void AI_약관분석_테스트() {
+        String dummyPdfText = """
+                무배당 삼성화재 다이렉트 실손의료비보험 (2601.6)
+                가입대상: 개인실손, 4세대
+                보장구조: 급여+비급여, 자기부담금 있음
+                
+                제1조 (기본보장)
+                급여 입원비, 급여 통원 치료비, 급여 약값을 보장합니다.
+                
+                제2조 (특약)
+                비급여 치료비, 3대 비급여(도수치료, 주사료, MRI)의 경우 별도 한도가 적용됩니다.
+                
+                제3조 (보상하지 않는 손해)
+                임신, 출산, 건강검진, 예방접종, 해외 의료기관 치료비는 보상하지 않습니다.
+                
+                제4조 (갱신 및 청구)
+                이 보험은 1년 갱신형이며 최대 5년 주기로 보장내용이 변경될 수 있습니다.
+                청구는 서류 접수 후 3영업일 이내에 지급하는 것을 기본으로 합니다.
+                """;
+
+        System.out.println("AI 분석중..");
+        long startTime = System.currentTimeMillis();
+
+        AnalysisResult result = aiAnalysisService.analysisPrompt(dummyPdfText);
+
+        long endTime = System.currentTimeMillis();
+        System.out.println("분석 완료 - 소요 시간: " + (endTime - startTime) + "ms");
+
+        System.out.println("=================[AI 분석결과]===========================");
+        System.out.println(result.toString());
+        System.out.println("=========================================================");
+    }
+
+}

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/analysis/service/AnalysisHistoryServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/analysis/service/AnalysisHistoryServiceTest.java
@@ -1,5 +1,6 @@
 package com.silsonfit.silsonfit_api.domain.analysis.service;
 
+import com.silsonfit.silsonfit_api.domain.analysis.dto.AnalysisHistoryCreateCommand;
 import com.silsonfit.silsonfit_api.domain.analysis.dto.AnalysisHistoryListResponse;
 import com.silsonfit.silsonfit_api.domain.analysis.entity.AnalysisHistory;
 import com.silsonfit.silsonfit_api.domain.analysis.repository.AnalysisHistoryRepository;
@@ -28,10 +29,11 @@ class AnalysisHistoryServiceTest {
 
     @BeforeEach
     void setUp() {
-        dummy1 = AnalysisHistory.create(1L, "test1.pdf", "test1", "testCompany1",
-                "testProduct1", "testType1", "1", "testCoverage1", "testPoint1", null);
-        dummy2 = AnalysisHistory.create(1L, "test2.pdf", "test2", "testCompany2",
-                "testProduct2", "testType2", "2", "testCoverage2", "testPoint2", null);
+
+        dummy1 = AnalysisHistory.create(new AnalysisHistoryCreateCommand(1L, "test1.pdf", "test1", "testCompany1",
+                "testProduct1", "testType1", "1", "testCoverage1", "testPoint1", null));
+        dummy2 = AnalysisHistory.create(new AnalysisHistoryCreateCommand(1L, "test2.pdf", "test2", "testCompany2",
+                "testProduct2", "testType2", "2", "testCoverage2", "testPoint2", null));
         analysisHistoryRepository.saveAll(List.of(dummy1, dummy2));
     }
 

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/analysis/service/AnalysisServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/analysis/service/AnalysisServiceTest.java
@@ -1,0 +1,74 @@
+package com.silsonfit.silsonfit_api.domain.analysis.service;
+
+import com.silsonfit.silsonfit_api.domain.analysis.dto.AnalysisHistoryDetailResponse;
+import com.silsonfit.silsonfit_api.domain.analysis.dto.AnalysisTaskDTO;
+import com.silsonfit.silsonfit_api.domain.analysis.repository.AnalysisHistoryRepository;
+import com.silsonfit.silsonfit_api.domain.analysis.vo.AnalysisResult;
+import com.silsonfit.silsonfit_api.global.aws.S3Service;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class AnalysisServiceTest {
+
+    // 서비스가 의존하는 객체들을 Mock 객체로 생성
+    @Mock
+    AnalysisHistoryRepository analysisHistoryRepository;
+    @Mock
+    SseEmitters sseEmitters;
+    @Mock
+    PdfService pdfService;
+    @Mock
+    AiAnalysisService aiAnalysisService;
+    @Mock
+    S3Service s3Service;
+
+    // Mock 객체들을 서비스에 주입
+    @InjectMocks
+    AnalysisService analysisService;
+
+    @Test
+    void PDF_업로드_AI분석_S3업로드_SSE전송_통합테스트() {
+        Long userId = 1L;
+        String clientId = "test-clientId";
+        byte[] dummyBytes = "dummy pdf".getBytes();
+        String contentType = "application/pdf";
+        String originalFileName = "약관.pdf";
+
+        AnalysisTaskDTO taskDTO = new AnalysisTaskDTO(userId, clientId, null, dummyBytes, contentType, originalFileName);
+
+        // 테스트용 가짜분석 결과
+        AnalysisResult.Metadata metadata = new AnalysisResult.Metadata("testCompany", "testProduct", "testContract",
+                "3세대", "testCoverage", "testCaution");
+        AnalysisResult dummyResult = new AnalysisResult(metadata, null);
+
+        // Mock 객체 호출 시나리오
+        when(s3Service.upload(dummyBytes, originalFileName, contentType))
+                .thenReturn("https://s3-dummy-url.com/약관.pdf");
+        when(pdfService.extractText(dummyBytes))
+                .thenReturn("추출된 약관 텍스트");
+        when(aiAnalysisService.analysisPrompt("추출된 약관 텍스트"))
+                .thenReturn(dummyResult);
+
+        analysisService.analysis(taskDTO);
+
+        // s3 업로드 호출 검증
+        verify(s3Service).upload(dummyBytes, originalFileName, contentType);
+
+        // ai 분석 호출 검증
+        verify(aiAnalysisService).analysisPrompt("추출된 약관 텍스트");
+
+        // db 저장 호출 검증
+        verify(analysisHistoryRepository).save(any());
+
+        // 프론트로 sse 가 전송 됐는지 검증
+        verify(sseEmitters).send(eq(clientId), eq("analysisComplete"), any(AnalysisHistoryDetailResponse.class));
+        verify(sseEmitters).complete(clientId);
+    }
+
+}

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/analysis/service/PdfServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/analysis/service/PdfServiceTest.java
@@ -1,0 +1,34 @@
+package com.silsonfit.silsonfit_api.domain.analysis.service;
+
+import org.junit.jupiter.api.Test;
+import org.springframework.mock.web.MockMultipartFile;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+
+class PdfServiceTest {
+
+    PdfService pdfService = new PdfService();
+
+    @Test
+    void 텍스트_추출_테스트() throws IOException {
+        File pdfFile = new File("C:\\Java\\공공데이터 제공및이용업무운영지침.pdf");
+
+        byte[] content = Files.readAllBytes(pdfFile.toPath());
+        MockMultipartFile mockFile = new MockMultipartFile(
+                "file",
+                pdfFile.getName(),
+                "application/pdf",
+                content
+        );
+
+        String result = pdfService.extractText(mockFile.getBytes());
+
+        System.out.println("=================[파싱된 텍스트 결과]======================");
+        System.out.println(result.substring(0, 21700));
+        System.out.println("=========================================================");
+
+    }
+
+}

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/global/aws/S3ServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/global/aws/S3ServiceTest.java
@@ -1,0 +1,62 @@
+package com.silsonfit.silsonfit_api.global.aws;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.Mockito;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+import software.amazon.awssdk.core.sync.RequestBody;
+import software.amazon.awssdk.services.s3.S3Client;
+import software.amazon.awssdk.services.s3.model.PutObjectRequest;
+import software.amazon.awssdk.services.s3.model.PutObjectResponse;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.*;
+
+@ExtendWith(MockitoExtension.class)
+class S3ServiceTest {
+
+    // Mock 객체 사용
+    @Mock
+    S3Client s3Client;
+
+    // Mock S3Client 를 S3Service 에 주입
+    @InjectMocks
+    S3Service s3Service;
+
+    @BeforeEach
+    void setUp() {
+        // @Value("${aws.s3.bucket}")에 들어갈 값을 테스트용으로 주입
+        ReflectionTestUtils.setField(s3Service, "bucket", "test-bucket");
+
+        // @Value("${aws.s3.region}")에 들어갈 값을 테스트용으로 주입
+        ReflectionTestUtils.setField(s3Service, "region", "ap-northeast-2");
+    }
+
+    @Test
+    void PDF_S3_업로드_테스트() {
+        byte[] dummyFileBytes = "dummy pdf content".getBytes();
+        String originalFileName = "test_약관.pdf";
+        String contentType = "application/pdf";
+
+        when(s3Client.putObject(any(PutObjectRequest.class), any(RequestBody.class)))
+                .thenReturn(PutObjectResponse.builder().build());
+
+        String resultUrl = s3Service.upload(dummyFileBytes, originalFileName, contentType);
+
+        System.out.println("생성된 S3 URL : " + resultUrl);
+
+        // URL 이 https:~로 시작하는지
+        assertThat(resultUrl).startsWith("https://test-bucket.s3.ap-northeast-2.amazonaws.com/");
+
+        // URL 끝에 원본 파일명이 잘 붙어있는지
+        assertThat(resultUrl).endsWith(originalFileName);
+
+        // s3 업로드 중 s3Client 의 putObject 메서드가 실행됐는지 확인
+        verify(s3Client).putObject(any(PutObjectRequest.class), any(RequestBody.class));
+    }
+}


### PR DESCRIPTION
<!-- PR의 타입은 Label을 통해 나타내주세요. -->

### 💻 작업 내용
<!-- 진행한 작업 내용에 대해 작성해주세요. -->
- PDF 텍스트 추출 기능 구현
- S3 업로드 기능 구현
- 실시간 통신을 위한 SSE 구현
- AI 약관 분석 기능 구현 (Gemini Tier1 사용)
- 각 기능들의 테스트 코드 작성

### ✨ 리뷰 포인트
<!-- (ex) query 가 너무 복잡한 것 같은데 이 위주로 봐주세요. -->

### 📝 메모
<!-- PR 관련 전달사항이 있다면 이곳에 작성해주세요. -->
- 약관분석 서비스에 내 보험을 선택해서 분석할 경우는 주석 처리해놓았는데 나중에 보험 엔티티, 유저보험 엔티티 추가되면
주석해제하고 테스트 해본 뒤 pr 요청 예정입니다.
- AI 같은 경우에는 테스트 용으로 Ollama, 배포용으로 Gemini 프리티어를 사용할 생각이었지만, Ollama 같은 경우 단기 기억력의 한계 이슈로 15만자를 분석하다가 앞의 내용을 까먹어서 결과를 JSON 형식으로 주지 않아서 테스트도 해보지 못했습니다..
Gemini 프리티어 같은 경우 텍스트 15만자를 요청했을 때 토큰 한도가 초과될 뿐더러 무료이다보니 트래픽이 몰려 계속 요청 거부 당함.
그래서 결국 Gemini Tier1 등록 해놨습니다. (pdf 1번 분석하는데 약 50 ~ 80원 드는듯 하네요)
- AWS S3 같은 경우에도 일단 버킷 생성하는건 어렵지 않아서 제걸로 해놨는데 나중에 서버를 영준님 계정으로 판다면 버킷도 같이 옮기면 되지 않을까 싶습니다.

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
closed #20 
