### PR TITLE
feat: 실손 보험 계산 API 구현

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationController.java
@@ -3,10 +3,12 @@ package com.silsonfit.silsonfit_api.domain.calculation.controller;
 import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationRequest;
 import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationResponse;
 import com.silsonfit.silsonfit_api.domain.calculation.service.CalculationService;
+import com.silsonfit.silsonfit_api.global.auth.CustomUserDetails;
 import com.silsonfit.silsonfit_api.global.common.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -31,15 +33,19 @@ public class CalculationController {
      */
     @PostMapping
     public ApiResponse<CalculationResponse> calculate(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody CalculationRequest request
     ) {
+        Long userId = userDetails.getUserId();
+
         log.info(
-                "실손 보험 계산 요청 - insuranceId={}, medicalCost={}, ediCode={}",
+                "실손 보험 계산 요청 - userId={}, insuranceId={}, medicalCost={}, ediCode={}",
+                userId,
                 request.getInsuranceId(),
                 request.getMedicalCost(),
                 request.getEdiCode()
         );
 
-        return ApiResponse.success(calculationService.calculate(request));
+        return ApiResponse.success(calculationService.calculate(userId, request));
     }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationController.java
@@ -1,0 +1,45 @@
+package com.silsonfit.silsonfit_api.domain.calculation.controller;
+
+import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationRequest;
+import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationResponse;
+import com.silsonfit.silsonfit_api.domain.calculation.service.CalculationService;
+import com.silsonfit.silsonfit_api.global.common.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 실손 보험 계산 API
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/calculations")
+public class CalculationController {
+
+    private final CalculationService calculationService;
+
+    /**
+     * 실손 보험 예상 환급액 계산
+     *
+     * @param request 계산 요청
+     * @return 계산 결과
+     */
+    @PostMapping
+    public ApiResponse<CalculationResponse> calculate(
+            @Valid @RequestBody CalculationRequest request
+    ) {
+        log.info(
+                "실손 보험 계산 요청 - insuranceId={}, medicalCost={}, ediCode={}",
+                request.getInsuranceId(),
+                request.getMedicalCost(),
+                request.getEdiCode()
+        );
+
+        return ApiResponse.success(calculationService.calculate(request));
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/repository/CalculationHistoryRepository.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/repository/CalculationHistoryRepository.java
@@ -1,0 +1,10 @@
+package com.silsonfit.silsonfit_api.domain.calculation.repository;
+
+import com.silsonfit.silsonfit_api.domain.calculation.entity.CalculationHistory;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 실손 보험 계산 이력 Repository
+ */
+public interface CalculationHistoryRepository extends JpaRepository<CalculationHistory, Long> {
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/repository/EdiCodeRepository.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/repository/EdiCodeRepository.java
@@ -1,0 +1,17 @@
+package com.silsonfit.silsonfit_api.domain.calculation.repository;
+
+import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+import java.util.Optional;
+
+/**
+ * EDI 수가 코드 Repository
+ */
+public interface EdiCodeRepository extends JpaRepository<EdiCode, Long> {
+
+    /**
+     * 수가 코드 기반 EDI 코드 조회
+     */
+    Optional<EdiCode> findByCode(String code);
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationService.java
@@ -1,0 +1,86 @@
+package com.silsonfit.silsonfit_api.domain.calculation.service;
+
+import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationRequest;
+import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationResponse;
+import com.silsonfit.silsonfit_api.domain.calculation.entity.CoverageRule;
+import com.silsonfit.silsonfit_api.domain.calculation.vo.CalculationResult;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 실손 보험 계산 Service
+ *
+ * - 요청 조건에 맞는 보장 룰을 조회한다.
+ * - 조회된 보장 룰의 보장 여부, 보장률, 자기부담금, 한도를 기준으로 예상 환급액을 계산한다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CalculationService {
+
+    private final CoverageRuleResolver coverageRuleResolver;
+
+    /**
+     * 실손 보험 예상 환급액 계산
+     *
+     * @param request 계산 요청
+     * @return 계산 응답
+     */
+    public CalculationResponse calculate(CalculationRequest request) {
+        CoverageRule coverageRule = coverageRuleResolver.resolve(
+                request.getInsuranceId(),
+                request.getEdiCode(),
+                request.getVisitType(),
+                request.getTreatmentCategory(),
+                request.getPurposeType()
+        );
+
+        CalculationResult result = calculateByRule(request.getMedicalCost(), coverageRule);
+        return CalculationResponse.from(result);
+    }
+
+    /**
+     * 보장 룰 기반 계산 수행
+     */
+    private CalculationResult calculateByRule(Integer medicalCost, CoverageRule coverageRule) {
+        if (!coverageRule.getIsCovered()) {
+            return CalculationResult.of(
+                    false,
+                    0,
+                    medicalCost,
+                    List.of(coverageRule.getBasis()),
+                    coverageRule.getDisclaimer()
+            );
+        }
+
+        int refundAmountByRate = medicalCost * coverageRule.getCoverageRate() / 100;
+        int limitedRefundAmount = applyLimit(refundAmountByRate, coverageRule.getLimitAmount());
+        int deductibleAmount = Math.max(
+                coverageRule.getDeductibleAmount(),
+                medicalCost - limitedRefundAmount
+        );
+        int refundAmount = Math.max(medicalCost - deductibleAmount, 0);
+
+        return CalculationResult.of(
+                true,
+                refundAmount,
+                deductibleAmount,
+                List.of(coverageRule.getBasis()),
+                coverageRule.getDisclaimer()
+        );
+    }
+
+    /**
+     * 보장 한도 적용
+     */
+    private int applyLimit(int refundAmount, Integer limitAmount) {
+        if (limitAmount == null) {
+            return refundAmount;
+        }
+
+        return Math.min(refundAmount, limitAmount);
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationService.java
@@ -2,7 +2,9 @@ package com.silsonfit.silsonfit_api.domain.calculation.service;
 
 import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationRequest;
 import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationResponse;
+import com.silsonfit.silsonfit_api.domain.calculation.entity.CalculationHistory;
 import com.silsonfit.silsonfit_api.domain.calculation.entity.CoverageRule;
+import com.silsonfit.silsonfit_api.domain.calculation.repository.CalculationHistoryRepository;
 import com.silsonfit.silsonfit_api.domain.calculation.vo.CalculationResult;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -22,14 +24,17 @@ import java.util.List;
 public class CalculationService {
 
     private final CoverageRuleResolver coverageRuleResolver;
+    private final CalculationHistoryRepository calculationHistoryRepository;
 
     /**
      * 실손 보험 예상 환급액 계산
      *
+     * @param userId 사용자 ID
      * @param request 계산 요청
      * @return 계산 응답
      */
-    public CalculationResponse calculate(CalculationRequest request) {
+    @Transactional
+    public CalculationResponse calculate(Long userId, CalculationRequest request) {
         CoverageRule coverageRule = coverageRuleResolver.resolve(
                 request.getInsuranceId(),
                 request.getEdiCode(),
@@ -39,7 +44,30 @@ public class CalculationService {
         );
 
         CalculationResult result = calculateByRule(request.getMedicalCost(), coverageRule);
+        saveHistory(userId, request, result);
         return CalculationResponse.from(result);
+    }
+
+    /**
+     * 계산 결과 이력 저장
+     */
+    private void saveHistory(
+            Long userId,
+            CalculationRequest request,
+            CalculationResult result
+    ) {
+        CalculationHistory history = CalculationHistory.create(
+                userId,
+                request.getInsuranceId(),
+                request.getMedicalCost(),
+                request.getTreatmentCategory(),
+                request.getEdiCode(),
+                result.getIsCovered(),
+                result.getRefundAmount(),
+                result.getDeductibleAmount()
+        );
+
+        calculationHistoryRepository.save(history);
     }
 
     /**

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleResolver.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleResolver.java
@@ -1,0 +1,78 @@
+package com.silsonfit.silsonfit_api.domain.calculation.service;
+
+import com.silsonfit.silsonfit_api.domain.calculation.entity.CoverageRule;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.PurposeType;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.VisitType;
+import com.silsonfit.silsonfit_api.domain.calculation.repository.CoverageRuleRepository;
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.util.StringUtils;
+
+/**
+ * 보장 룰 조회 Resolver
+ *
+ * - EDI 코드가 있으면 보험 ID + EDI 코드 기반 룰을 우선 조회한다.
+ * - EDI 코드가 없거나 EDI 기반 룰이 없으면 진료 유형/항목/목적 기반 룰로 대체 조회한다.
+ */
+@Service
+@RequiredArgsConstructor
+public class CoverageRuleResolver {
+
+    private final CoverageRuleRepository coverageRuleRepository;
+
+    /**
+     * 계산 요청 조건에 맞는 보장 룰 조회
+     *
+     * @param insuranceId 보험 ID
+     * @param ediCode EDI 코드
+     * @param visitType 진료 유형
+     * @param treatmentCategory 진료 항목
+     * @param purposeType 진료 목적
+     * @return 계산에 사용할 보장 룰
+     */
+    public CoverageRule resolve(
+            Long insuranceId,
+            String ediCode,
+            VisitType visitType,
+            TreatmentCategory treatmentCategory,
+            PurposeType purposeType
+    ) {
+        if (StringUtils.hasText(ediCode)) {
+            return coverageRuleRepository.findByInsuranceIdAndEdiCode(insuranceId, ediCode.trim())
+                    .orElseGet(() -> resolveByTreatmentInfo(
+                            insuranceId,
+                            visitType,
+                            treatmentCategory,
+                            purposeType
+                    ));
+        }
+
+        return resolveByTreatmentInfo(
+                insuranceId,
+                visitType,
+                treatmentCategory,
+                purposeType
+        );
+    }
+
+    /**
+     * 진료 유형/항목/목적 기반 보장 룰 조회
+     */
+    private CoverageRule resolveByTreatmentInfo(
+            Long insuranceId,
+            VisitType visitType,
+            TreatmentCategory treatmentCategory,
+            PurposeType purposeType
+    ) {
+        return coverageRuleRepository.findByInsuranceIdAndVisitTypeAndTreatmentCategoryAndPurposeType(
+                        insuranceId,
+                        visitType,
+                        treatmentCategory,
+                        purposeType
+                )
+                .orElseThrow(() -> new BusinessException(ErrorCode.COVERAGE_RULE_NOT_FOUND));
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/EdiCodeResolver.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/EdiCodeResolver.java
@@ -1,0 +1,39 @@
+package com.silsonfit.silsonfit_api.domain.calculation.service;
+
+import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
+import com.silsonfit.silsonfit_api.domain.calculation.repository.EdiCodeRepository;
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+import org.springframework.util.StringUtils;
+
+/**
+ * EDI 코드 조회 Resolver
+ *
+ * - 우선 DB에 저장된 EDI 수가 코드를 조회한다.
+ * - DB에 없는 경우 추후 공공 API 조회 로직으로 확장한다.
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class EdiCodeResolver {
+
+    private final EdiCodeRepository ediCodeRepository;
+
+    /**
+     * 수가 코드에 해당하는 EDI 코드 조회
+     *
+     * @param code 수가 코드
+     * @return EDI 코드
+     */
+    public EdiCode resolve(String code) {
+        if (!StringUtils.hasText(code)) {
+            throw new BusinessException(ErrorCode.EDI_CODE_NOT_FOUND);
+        }
+
+        return ediCodeRepository.findByCode(code.trim())
+                .orElseThrow(() -> new BusinessException(ErrorCode.EDI_CODE_NOT_FOUND));
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
@@ -39,6 +39,7 @@ public enum ErrorCode {
 
     // ── Calculator ──
     COVERAGE_RULE_NOT_FOUND(404, "보장 룰을 찾을 수 없습니다."),
+    EDI_CODE_NOT_FOUND(404, "EDI 코드를 찾을 수 없습니다."),
 
     ;
 

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
@@ -38,6 +38,7 @@ public enum ErrorCode {
     // ── Insurance ──
 
     // ── Calculator ──
+    COVERAGE_RULE_NOT_FOUND(404, "보장 룰을 찾을 수 없습니다."),
 
     ;
 

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationControllerTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationControllerTest.java
@@ -6,6 +6,7 @@ import com.silsonfit.silsonfit_api.domain.calculation.enums.PurposeType;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.VisitType;
 import com.silsonfit.silsonfit_api.domain.calculation.service.CalculationService;
+import com.silsonfit.silsonfit_api.global.auth.CustomUserDetails;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -18,6 +19,7 @@ import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
@@ -46,10 +48,10 @@ class CalculationControllerTest {
                 .disclaimer("주의사항")
                 .build();
 
-        when(calculationService.calculate(any())).thenReturn(response);
+        when(calculationService.calculate(eq(1L), any())).thenReturn(response);
 
         mockMvc.perform(post("/api/calculations")
-                        .with(user("test-user"))
+                        .with(user(new CustomUserDetails(1L)))
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
@@ -73,7 +75,7 @@ class CalculationControllerTest {
 
         org.mockito.ArgumentCaptor<CalculationRequest> requestCaptor =
                 org.mockito.ArgumentCaptor.forClass(CalculationRequest.class);
-        verify(calculationService).calculate(requestCaptor.capture());
+        verify(calculationService).calculate(eq(1L), requestCaptor.capture());
 
         CalculationRequest capturedRequest = requestCaptor.getValue();
         assertThat(capturedRequest.getInsuranceId()).isEqualTo(1L);
@@ -88,7 +90,7 @@ class CalculationControllerTest {
     @DisplayName("필수 요청값이 없으면 400 응답을 반환한다")
     void calculate_invalidRequest() throws Exception {
         mockMvc.perform(post("/api/calculations")
-                        .with(user("test-user"))
+                        .with(user(new CustomUserDetails(1L)))
                         .with(csrf())
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationControllerTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationControllerTest.java
@@ -1,0 +1,107 @@
+package com.silsonfit.silsonfit_api.domain.calculation.controller;
+
+import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationRequest;
+import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationResponse;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.PurposeType;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.VisitType;
+import com.silsonfit.silsonfit_api.domain.calculation.service.CalculationService;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.http.MediaType;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CalculationController.class)
+class CalculationControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    CalculationService calculationService;
+
+    @Test
+    @DisplayName("계산 요청을 처리하고 ApiResponse로 계산 결과를 반환한다")
+    void calculate_success() throws Exception {
+        CalculationResponse response = CalculationResponse.builder()
+                .isCovered(true)
+                .refundAmount(70000)
+                .deductibleAmount(30000)
+                .basis(List.of("계산 근거"))
+                .disclaimer("주의사항")
+                .build();
+
+        when(calculationService.calculate(any())).thenReturn(response);
+
+        mockMvc.perform(post("/api/calculations")
+                        .with(user("test-user"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "insuranceId": 1,
+                                  "medicalCost": 100000,
+                                  "visitType": "OUTPATIENT",
+                                  "treatmentCategory": "MRI",
+                                  "purposeType": "TREATMENT",
+                                  "ediCode": "EDI001"
+                                }
+                                """))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"))
+                .andExpect(jsonPath("$.data.isCovered").value(true))
+                .andExpect(jsonPath("$.data.refundAmount").value(70000))
+                .andExpect(jsonPath("$.data.deductibleAmount").value(30000))
+                .andExpect(jsonPath("$.data.basis[0]").value("계산 근거"))
+                .andExpect(jsonPath("$.data.disclaimer").value("주의사항"));
+
+        org.mockito.ArgumentCaptor<CalculationRequest> requestCaptor =
+                org.mockito.ArgumentCaptor.forClass(CalculationRequest.class);
+        verify(calculationService).calculate(requestCaptor.capture());
+
+        CalculationRequest capturedRequest = requestCaptor.getValue();
+        assertThat(capturedRequest.getInsuranceId()).isEqualTo(1L);
+        assertThat(capturedRequest.getMedicalCost()).isEqualTo(100000);
+        assertThat(capturedRequest.getVisitType()).isEqualTo(VisitType.OUTPATIENT);
+        assertThat(capturedRequest.getTreatmentCategory()).isEqualTo(TreatmentCategory.MRI);
+        assertThat(capturedRequest.getPurposeType()).isEqualTo(PurposeType.TREATMENT);
+        assertThat(capturedRequest.getEdiCode()).isEqualTo("EDI001");
+    }
+
+    @Test
+    @DisplayName("필수 요청값이 없으면 400 응답을 반환한다")
+    void calculate_invalidRequest() throws Exception {
+        mockMvc.perform(post("/api/calculations")
+                        .with(user("test-user"))
+                        .with(csrf())
+                        .contentType(MediaType.APPLICATION_JSON)
+                        .content("""
+                                {
+                                  "insuranceId": 1,
+                                  "medicalCost": 100000,
+                                  "visitType": "OUTPATIENT",
+                                  "treatmentCategory": "MRI"
+                                }
+                                """))
+                .andExpect(status().isBadRequest())
+                .andExpect(jsonPath("$.code").value(400))
+                .andExpect(jsonPath("$.message").value("잘못된 입력입니다."))
+                .andExpect(jsonPath("$.data").isEmpty());
+    }
+}

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationServiceTest.java
@@ -1,0 +1,110 @@
+package com.silsonfit.silsonfit_api.domain.calculation.service;
+
+import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationRequest;
+import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationResponse;
+import com.silsonfit.silsonfit_api.domain.calculation.entity.CoverageRule;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.PurposeType;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.VisitType;
+import com.silsonfit.silsonfit_api.domain.calculation.repository.CoverageRuleRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.util.ReflectionTestUtils;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class CalculationServiceTest {
+
+    @Autowired
+    CalculationService calculationService;
+
+    @Autowired
+    CoverageRuleRepository coverageRuleRepository;
+
+    @Test
+    void 보장_대상이면_보장률에_따라_환급액과_자기부담금을_계산한다() {
+        coverageRuleRepository.save(createCoverageRule(
+                true,
+                70,
+                10000,
+                null
+        ));
+        CalculationRequest request = createCalculationRequest(100000);
+
+        CalculationResponse response = calculationService.calculate(request);
+
+        assertThat(response.getIsCovered()).isTrue();
+        assertThat(response.getRefundAmount()).isEqualTo(70000);
+        assertThat(response.getDeductibleAmount()).isEqualTo(30000);
+    }
+
+    @Test
+    void 고정_자기부담금이_더_크면_고정_자기부담금을_적용한다() {
+        coverageRuleRepository.save(createCoverageRule(
+                true,
+                95,
+                10000,
+                null
+        ));
+        CalculationRequest request = createCalculationRequest(100000);
+
+        CalculationResponse response = calculationService.calculate(request);
+
+        assertThat(response.getIsCovered()).isTrue();
+        assertThat(response.getRefundAmount()).isEqualTo(90000);
+        assertThat(response.getDeductibleAmount()).isEqualTo(10000);
+    }
+
+    @Test
+    void 보장_제외이면_환급액은_0원이고_자기부담금은_의료비_전액이다() {
+        coverageRuleRepository.save(createCoverageRule(
+                false,
+                0,
+                0,
+                null
+        ));
+        CalculationRequest request = createCalculationRequest(100000);
+
+        CalculationResponse response = calculationService.calculate(request);
+
+        assertThat(response.getIsCovered()).isFalse();
+        assertThat(response.getRefundAmount()).isZero();
+        assertThat(response.getDeductibleAmount()).isEqualTo(100000);
+    }
+
+    private CoverageRule createCoverageRule(
+            Boolean isCovered,
+            Integer coverageRate,
+            Integer deductibleAmount,
+            Integer limitAmount
+    ) {
+        return CoverageRule.create(
+                1L,
+                null,
+                VisitType.OUTPATIENT,
+                TreatmentCategory.MRI,
+                PurposeType.TREATMENT,
+                isCovered,
+                coverageRate,
+                deductibleAmount,
+                limitAmount,
+                "계산 테스트 룰",
+                null
+        );
+    }
+
+    private CalculationRequest createCalculationRequest(Integer medicalCost) {
+        CalculationRequest request = new CalculationRequest();
+        ReflectionTestUtils.setField(request, "insuranceId", 1L);
+        ReflectionTestUtils.setField(request, "medicalCost", medicalCost);
+        ReflectionTestUtils.setField(request, "visitType", VisitType.OUTPATIENT);
+        ReflectionTestUtils.setField(request, "treatmentCategory", TreatmentCategory.MRI);
+        ReflectionTestUtils.setField(request, "purposeType", PurposeType.TREATMENT);
+        ReflectionTestUtils.setField(request, "ediCode", null);
+        return request;
+    }
+}

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationServiceTest.java
@@ -2,10 +2,12 @@ package com.silsonfit.silsonfit_api.domain.calculation.service;
 
 import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationRequest;
 import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationResponse;
+import com.silsonfit.silsonfit_api.domain.calculation.entity.CalculationHistory;
 import com.silsonfit.silsonfit_api.domain.calculation.entity.CoverageRule;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.PurposeType;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.VisitType;
+import com.silsonfit.silsonfit_api.domain.calculation.repository.CalculationHistoryRepository;
 import com.silsonfit.silsonfit_api.domain.calculation.repository.CoverageRuleRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -25,6 +27,9 @@ class CalculationServiceTest {
     @Autowired
     CoverageRuleRepository coverageRuleRepository;
 
+    @Autowired
+    CalculationHistoryRepository calculationHistoryRepository;
+
     @Test
     void 보장_대상이면_보장률에_따라_환급액과_자기부담금을_계산한다() {
         coverageRuleRepository.save(createCoverageRule(
@@ -35,11 +40,19 @@ class CalculationServiceTest {
         ));
         CalculationRequest request = createCalculationRequest(100000);
 
-        CalculationResponse response = calculationService.calculate(request);
+        CalculationResponse response = calculationService.calculate(1L, request);
 
         assertThat(response.getIsCovered()).isTrue();
         assertThat(response.getRefundAmount()).isEqualTo(70000);
         assertThat(response.getDeductibleAmount()).isEqualTo(30000);
+
+        CalculationHistory history = calculationHistoryRepository.findAll().get(0);
+        assertThat(history.getUserId()).isEqualTo(1L);
+        assertThat(history.getInsuranceId()).isEqualTo(1L);
+        assertThat(history.getMedicalCost()).isEqualTo(100000);
+        assertThat(history.getTreatmentCategory()).isEqualTo(TreatmentCategory.MRI);
+        assertThat(history.getRefundAmount()).isEqualTo(70000);
+        assertThat(history.getDeductibleAmount()).isEqualTo(30000);
     }
 
     @Test
@@ -52,7 +65,7 @@ class CalculationServiceTest {
         ));
         CalculationRequest request = createCalculationRequest(100000);
 
-        CalculationResponse response = calculationService.calculate(request);
+        CalculationResponse response = calculationService.calculate(1L, request);
 
         assertThat(response.getIsCovered()).isTrue();
         assertThat(response.getRefundAmount()).isEqualTo(90000);
@@ -69,7 +82,7 @@ class CalculationServiceTest {
         ));
         CalculationRequest request = createCalculationRequest(100000);
 
-        CalculationResponse response = calculationService.calculate(request);
+        CalculationResponse response = calculationService.calculate(1L, request);
 
         assertThat(response.getIsCovered()).isFalse();
         assertThat(response.getRefundAmount()).isZero();

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleResolverTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleResolverTest.java
@@ -1,0 +1,118 @@
+package com.silsonfit.silsonfit_api.domain.calculation.service;
+
+import com.silsonfit.silsonfit_api.domain.calculation.entity.CoverageRule;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.PurposeType;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.VisitType;
+import com.silsonfit.silsonfit_api.domain.calculation.repository.CoverageRuleRepository;
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+class CoverageRuleResolverTest {
+
+    @Autowired
+    CoverageRuleResolver coverageRuleResolver;
+
+    @Autowired
+    CoverageRuleRepository coverageRuleRepository;
+
+    @Test
+    void EDI코드_기반_보장룰이_있으면_우선_반환한다() {
+        CoverageRule ediRule = createCoverageRule(
+                1L,
+                "EDI001",
+                VisitType.OUTPATIENT,
+                TreatmentCategory.MRI,
+                PurposeType.TREATMENT,
+                "EDI 룰"
+        );
+        CoverageRule treatmentInfoRule = createCoverageRule(
+                1L,
+                null,
+                VisitType.OUTPATIENT,
+                TreatmentCategory.MRI,
+                PurposeType.TREATMENT,
+                "진료정보 룰"
+        );
+        coverageRuleRepository.save(ediRule);
+        coverageRuleRepository.save(treatmentInfoRule);
+
+        CoverageRule resolvedRule = coverageRuleResolver.resolve(
+                1L,
+                "EDI001",
+                VisitType.OUTPATIENT,
+                TreatmentCategory.MRI,
+                PurposeType.TREATMENT
+        );
+
+        assertThat(resolvedRule.getBasis()).isEqualTo("EDI 룰");
+    }
+
+    @Test
+    void EDI코드_기반_보장룰이_없으면_진료정보_기반_보장룰을_반환한다() {
+        CoverageRule treatmentInfoRule = createCoverageRule(
+                1L,
+                null,
+                VisitType.OUTPATIENT,
+                TreatmentCategory.MRI,
+                PurposeType.TREATMENT,
+                "진료정보 룰"
+        );
+        coverageRuleRepository.save(treatmentInfoRule);
+
+        CoverageRule resolvedRule = coverageRuleResolver.resolve(
+                1L,
+                "UNKNOWN_EDI",
+                VisitType.OUTPATIENT,
+                TreatmentCategory.MRI,
+                PurposeType.TREATMENT
+        );
+
+        assertThat(resolvedRule.getBasis()).isEqualTo("진료정보 룰");
+    }
+
+    @Test
+    void 조회되는_보장룰이_없으면_예외가_발생한다() {
+        assertThatThrownBy(() -> coverageRuleResolver.resolve(
+                1L,
+                "UNKNOWN_EDI",
+                VisitType.OUTPATIENT,
+                TreatmentCategory.MRI,
+                PurposeType.TREATMENT
+        ))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.COVERAGE_RULE_NOT_FOUND.getMessage());
+    }
+
+    private CoverageRule createCoverageRule(
+            Long insuranceId,
+            String ediCode,
+            VisitType visitType,
+            TreatmentCategory treatmentCategory,
+            PurposeType purposeType,
+            String basis
+    ) {
+        return CoverageRule.create(
+                insuranceId,
+                ediCode,
+                visitType,
+                treatmentCategory,
+                purposeType,
+                true,
+                70,
+                10000,
+                null,
+                basis,
+                null
+        );
+    }
+}

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/EdiCodeResolverTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/EdiCodeResolverTest.java
@@ -1,0 +1,66 @@
+package com.silsonfit.silsonfit_api.domain.calculation.service;
+
+import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.FeeType;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.PayType;
+import com.silsonfit.silsonfit_api.domain.calculation.repository.EdiCodeRepository;
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+@Transactional
+class EdiCodeResolverTest {
+
+    @Autowired
+    EdiCodeResolver ediCodeResolver;
+
+    @Autowired
+    EdiCodeRepository ediCodeRepository;
+
+    @Test
+    void DB에_EDI코드가_있으면_반환한다() {
+        ediCodeRepository.save(createEdiCode("EDI001"));
+
+        EdiCode ediCode = ediCodeResolver.resolve("EDI001");
+
+        assertThat(ediCode.getCode()).isEqualTo("EDI001");
+        assertThat(ediCode.getTreatmentName()).isEqualTo("MRI 검사");
+    }
+
+    @Test
+    void DB에_EDI코드가_없으면_예외가_발생한다() {
+        assertThatThrownBy(() -> ediCodeResolver.resolve("UNKNOWN_EDI"))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.EDI_CODE_NOT_FOUND.getMessage());
+    }
+
+    @Test
+    void EDI코드가_공백이면_예외가_발생한다() {
+        assertThatThrownBy(() -> ediCodeResolver.resolve(" "))
+                .isInstanceOf(BusinessException.class)
+                .hasMessage(ErrorCode.EDI_CODE_NOT_FOUND.getMessage());
+    }
+
+    private EdiCode createEdiCode(String code) {
+        return EdiCode.create(
+                code,
+                "MRI 검사",
+                "MRI",
+                PayType.PAY,
+                100000,
+                BigDecimal.valueOf(123.45),
+                LocalDate.of(2026, 1, 1),
+                FeeType.MEDICAL
+        );
+    }
+}


### PR DESCRIPTION
### 💻 작업 내용

* 보장 룰 기반 실손 보험 계산 서비스 구현
* EDI 우선 보장 룰 조회 Resolver 추가
* EDI 코드 조회 Resolver 구현
* 실손 보험 계산 API 컨트롤러 추가
* 계산 결과 기반 이력 저장 로직 구현
* 관련 테스트 코드 작성 (Service / Resolver / Controller)

### ✨ 리뷰 포인트

* Controller → Service → Domain 호출 구조가 적절한지
* Resolver에서의 조회 책임 분리가 명확한지

### 📝 메모

* 모든 계산은 CoverageRule로 처리하려하고 합니다.
* CoverageRule은 두가지로 나누려고 합니다.
  1. EDI 코드와 보험 정보를 통해 CoverageRule을 생성
  2. MRI, CT + 입원, 치료 등 기본 조합은 seed로 넣어주기
* 현재는 EDI 코드 기반 조회를 우선으로 처리하고 있으며, EDI 코드가 없을 경우의 로직은 다음 PR에서 확장 예정입니다.
* API는 최소 기능 기준으로 구성되어 있으며, 이후 룰 생성/보완 로직이 추가될 예정입니다.

### 🎯 관련 이슈

closed #29 