### PR TITLE
feat: CoverageRule 자동 생성 및 fallback 처리 구현

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/client/EdiCodeClient.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/client/EdiCodeClient.java
@@ -1,0 +1,19 @@
+package com.silsonfit.silsonfit_api.domain.calculation.client;
+
+import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
+
+import java.util.Optional;
+
+/**
+ * 외부 EDI 수가 코드 조회 Client
+ */
+public interface EdiCodeClient {
+
+    /**
+     * 수가 코드 기반 EDI 코드 조회
+     *
+     * @param code 수가 코드
+     * @return 조회된 EDI 코드
+     */
+    Optional<EdiCode> fetchByCode(String code);
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/client/FakeEdiCodeClient.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/client/FakeEdiCodeClient.java
@@ -1,0 +1,79 @@
+package com.silsonfit.silsonfit_api.domain.calculation.client;
+
+import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.FeeType;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.PayType;
+import org.springframework.stereotype.Component;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+
+/**
+ * 공공 EDI API Fake Client
+ *
+ * - 실제 공공 API 연동 전까지 DB 미존재 EDI 코드 조회 흐름을 검증하기 위한 임시 구현체다.
+ * TODO(calculation): 실제 공공 API Client 구현 시 한방수가/진료수가/약국수가 API 응답을 EdiCode로 매핑한다.
+ */
+@Component
+public class FakeEdiCodeClient implements EdiCodeClient {
+
+    @Override
+    public Optional<EdiCode> fetchByCode(String code) {
+        return switch (code) {
+            case "Z3000030" -> Optional.of(create(
+                    "Z3000030",
+                    "복약지도료(방문당)-토요09-13",
+                    "약",
+                    PayType.PAY,
+                    260,
+                    BigDecimal.valueOf(3.3),
+                    LocalDate.of(2016, 1, 1),
+                    FeeType.PHARMACY
+            ));
+            case "MRI001" -> Optional.of(create(
+                    "MRI001",
+                    "MRI 검사",
+                    "MRI",
+                    PayType.NON_PAY,
+                    300000,
+                    BigDecimal.valueOf(120.5),
+                    LocalDate.of(2024, 1, 1),
+                    FeeType.MEDICAL
+            ));
+            case "MANUAL001" -> Optional.of(create(
+                    "MANUAL001",
+                    "도수치료",
+                    "도수",
+                    PayType.NON_PAY,
+                    100000,
+                    BigDecimal.valueOf(45.0),
+                    LocalDate.of(2024, 1, 1),
+                    FeeType.MEDICAL
+            ));
+            default -> Optional.empty();
+        };
+    }
+
+    private static EdiCode create(
+            String code,
+            String treatmentName,
+            String feeDivisionNumber,
+            PayType payType,
+            Integer unitPrice,
+            BigDecimal relativeValuePoint,
+            LocalDate effectiveStartDate,
+            FeeType feeType
+    ) {
+        return EdiCode.create(
+                code,
+                treatmentName,
+                feeDivisionNumber,
+                payType,
+                unitPrice,
+                relativeValuePoint,
+                effectiveStartDate,
+                feeType
+        );
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/entity/EdiCode.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/entity/EdiCode.java
@@ -100,6 +100,30 @@ public class EdiCode {
     }
 
     /**
+     * EDI 분류에 사용할 문자열 생성
+     *
+     * @return 수가 코드, 한글명, 수가 분류 번호를 합친 검색 문자열
+     */
+    public String getClassificationSource() {
+        return String.join(
+                " ",
+                nullToEmpty(code),
+                nullToEmpty(treatmentName),
+                nullToEmpty(feeDivisionNumber)
+        ).toUpperCase();
+    }
+
+    /**
+     * EDI 분류 문자열의 키워드 포함 여부 판단
+     *
+     * @param keyword 검색 키워드
+     * @return 포함 여부
+     */
+    public boolean containsKeyword(String keyword) {
+        return getClassificationSource().contains(keyword.toUpperCase());
+    }
+
+    /**
      * EDI 코드 생성
      *
      * @param code 수가 코드
@@ -131,5 +155,13 @@ public class EdiCode {
                 .effectiveStartDate(effectiveStartDate)
                 .feeType(feeType)
                 .build();
+    }
+
+    private String nullToEmpty(String value) {
+        if (value == null) {
+            return "";
+        }
+
+        return value;
     }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/AbstractCoverageRuleGenerationPolicy.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/AbstractCoverageRuleGenerationPolicy.java
@@ -1,0 +1,94 @@
+package com.silsonfit.silsonfit_api.domain.calculation.policy;
+
+import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.InsuranceGeneration;
+import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleGenerationContext;
+
+/**
+ * 세대별 보장 룰 생성 정책 기본 구현
+ */
+public abstract class AbstractCoverageRuleGenerationPolicy implements CoverageRuleGenerationPolicy {
+
+    private final InsuranceGeneration generation;
+    private final int payCoverageRate;
+    private final int payDeductibleAmount;
+    private final int nonPayCoverageRate;
+    private final int nonPayDeductibleAmount;
+    private final String disclaimer;
+
+    protected AbstractCoverageRuleGenerationPolicy(
+            InsuranceGeneration generation,
+            int payCoverageRate,
+            int payDeductibleAmount,
+            int nonPayCoverageRate,
+            int nonPayDeductibleAmount,
+            String disclaimer
+    ) {
+        this.generation = generation;
+        this.payCoverageRate = payCoverageRate;
+        this.payDeductibleAmount = payDeductibleAmount;
+        this.nonPayCoverageRate = nonPayCoverageRate;
+        this.nonPayDeductibleAmount = nonPayDeductibleAmount;
+        this.disclaimer = disclaimer;
+    }
+
+    @Override
+    public boolean supports(CoverageRuleGenerationContext context, EdiCode ediCode) {
+        return context.generation() == generation;
+    }
+
+    @Override
+    public boolean isCovered(CoverageRuleGenerationContext context, EdiCode ediCode) {
+        if (ediCode.containsKeyword("건강검진") || ediCode.containsKeyword("검진")) {
+            return false;
+        }
+        if (ediCode.containsKeyword("미용") || ediCode.containsKeyword("성형")) {
+            return false;
+        }
+        if (ediCode.containsKeyword("예방") || ediCode.containsKeyword("예방접종")) {
+            return false;
+        }
+
+        return true;
+    }
+
+    @Override
+    public int coverageRate(CoverageRuleGenerationContext context, EdiCode ediCode) {
+        if (!isCovered(context, ediCode)) {
+            return 0;
+        }
+
+        if (ediCode.isPay()) {
+            return payCoverageRate;
+        }
+
+        return nonPayCoverageRate;
+    }
+
+    @Override
+    public int deductibleAmount(CoverageRuleGenerationContext context, EdiCode ediCode) {
+        if (!isCovered(context, ediCode)) {
+            return 0;
+        }
+
+        if (ediCode.isPay()) {
+            return payDeductibleAmount;
+        }
+
+        return nonPayDeductibleAmount;
+    }
+
+    @Override
+    public Integer limitAmount(CoverageRuleGenerationContext context, EdiCode ediCode) {
+        if (ediCode.getUnitPrice() == null || ediCode.getUnitPrice() <= 0) {
+            return null;
+        }
+
+        return ediCode.getUnitPrice();
+    }
+
+    @Override
+    public String disclaimer(CoverageRuleGenerationContext context, EdiCode ediCode) {
+        return disclaimer;
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/AbstractCoverageRuleGenerationPolicy.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/AbstractCoverageRuleGenerationPolicy.java
@@ -2,7 +2,7 @@ package com.silsonfit.silsonfit_api.domain.calculation.policy;
 
 import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.InsuranceGeneration;
-import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleGenerationContext;
+import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleContext;
 
 /**
  * 세대별 보장 룰 생성 정책 기본 구현
@@ -33,12 +33,12 @@ public abstract class AbstractCoverageRuleGenerationPolicy implements CoverageRu
     }
 
     @Override
-    public boolean supports(CoverageRuleGenerationContext context, EdiCode ediCode) {
+    public boolean supports(CoverageRuleContext context, EdiCode ediCode) {
         return context.generation() == generation;
     }
 
     @Override
-    public boolean isCovered(CoverageRuleGenerationContext context, EdiCode ediCode) {
+    public boolean isCovered(CoverageRuleContext context, EdiCode ediCode) {
         if (ediCode.containsKeyword("건강검진") || ediCode.containsKeyword("검진")) {
             return false;
         }
@@ -53,7 +53,7 @@ public abstract class AbstractCoverageRuleGenerationPolicy implements CoverageRu
     }
 
     @Override
-    public int coverageRate(CoverageRuleGenerationContext context, EdiCode ediCode) {
+    public int coverageRate(CoverageRuleContext context, EdiCode ediCode) {
         if (!isCovered(context, ediCode)) {
             return 0;
         }
@@ -66,7 +66,7 @@ public abstract class AbstractCoverageRuleGenerationPolicy implements CoverageRu
     }
 
     @Override
-    public int deductibleAmount(CoverageRuleGenerationContext context, EdiCode ediCode) {
+    public int deductibleAmount(CoverageRuleContext context, EdiCode ediCode) {
         if (!isCovered(context, ediCode)) {
             return 0;
         }
@@ -79,7 +79,7 @@ public abstract class AbstractCoverageRuleGenerationPolicy implements CoverageRu
     }
 
     @Override
-    public Integer limitAmount(CoverageRuleGenerationContext context, EdiCode ediCode) {
+    public Integer limitAmount(CoverageRuleContext context, EdiCode ediCode) {
         if (ediCode.getUnitPrice() == null || ediCode.getUnitPrice() <= 0) {
             return null;
         }
@@ -88,7 +88,7 @@ public abstract class AbstractCoverageRuleGenerationPolicy implements CoverageRu
     }
 
     @Override
-    public String disclaimer(CoverageRuleGenerationContext context, EdiCode ediCode) {
+    public String disclaimer(CoverageRuleContext context, EdiCode ediCode) {
         return disclaimer;
     }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/CoverageRuleGenerationPolicy.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/CoverageRuleGenerationPolicy.java
@@ -1,7 +1,7 @@
 package com.silsonfit.silsonfit_api.domain.calculation.policy;
 
 import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
-import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleGenerationContext;
+import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleContext;
 
 /**
  * 보장 룰 생성 정책
@@ -14,30 +14,30 @@ public interface CoverageRuleGenerationPolicy {
     /**
      * 해당 정책 적용 가능 여부
      */
-    boolean supports(CoverageRuleGenerationContext context, EdiCode ediCode);
+    boolean supports(CoverageRuleContext context, EdiCode ediCode);
 
     /**
      * 보장 여부 결정
      */
-    boolean isCovered(CoverageRuleGenerationContext context, EdiCode ediCode);
+    boolean isCovered(CoverageRuleContext context, EdiCode ediCode);
 
     /**
      * 보장률 결정
      */
-    int coverageRate(CoverageRuleGenerationContext context, EdiCode ediCode);
+    int coverageRate(CoverageRuleContext context, EdiCode ediCode);
 
     /**
      * 자기부담금 결정
      */
-    int deductibleAmount(CoverageRuleGenerationContext context, EdiCode ediCode);
+    int deductibleAmount(CoverageRuleContext context, EdiCode ediCode);
 
     /**
      * 보장 한도 결정
      */
-    Integer limitAmount(CoverageRuleGenerationContext context, EdiCode ediCode);
+    Integer limitAmount(CoverageRuleContext context, EdiCode ediCode);
 
     /**
      * 면책/주의 문구
      */
-    String disclaimer(CoverageRuleGenerationContext context, EdiCode ediCode);
+    String disclaimer(CoverageRuleContext context, EdiCode ediCode);
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/CoverageRuleGenerationPolicy.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/CoverageRuleGenerationPolicy.java
@@ -1,0 +1,43 @@
+package com.silsonfit.silsonfit_api.domain.calculation.policy;
+
+import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
+import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleGenerationContext;
+
+/**
+ * 보장 룰 생성 정책
+ *
+ * - 보험 세대, 보험 ID, EDI 코드 정보에 따라 CoverageRule 생성 조건을 결정한다.
+ * - 기본 세대별 정책보다 구체적인 보험 ID별 정책을 더 높은 우선순위로 추가할 수 있다.
+ */
+public interface CoverageRuleGenerationPolicy {
+
+    /**
+     * 해당 정책 적용 가능 여부
+     */
+    boolean supports(CoverageRuleGenerationContext context, EdiCode ediCode);
+
+    /**
+     * 보장 여부 결정
+     */
+    boolean isCovered(CoverageRuleGenerationContext context, EdiCode ediCode);
+
+    /**
+     * 보장률 결정
+     */
+    int coverageRate(CoverageRuleGenerationContext context, EdiCode ediCode);
+
+    /**
+     * 자기부담금 결정
+     */
+    int deductibleAmount(CoverageRuleGenerationContext context, EdiCode ediCode);
+
+    /**
+     * 보장 한도 결정
+     */
+    Integer limitAmount(CoverageRuleGenerationContext context, EdiCode ediCode);
+
+    /**
+     * 면책/주의 문구
+     */
+    String disclaimer(CoverageRuleGenerationContext context, EdiCode ediCode);
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/FifthGenerationCoverageRuleGenerationPolicy.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/FifthGenerationCoverageRuleGenerationPolicy.java
@@ -1,0 +1,24 @@
+package com.silsonfit.silsonfit_api.domain.calculation.policy;
+
+import com.silsonfit.silsonfit_api.domain.calculation.enums.InsuranceGeneration;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * 5세대 실손보험 보장 룰 생성 정책
+ */
+@Component
+@Order(100)
+public class FifthGenerationCoverageRuleGenerationPolicy extends AbstractCoverageRuleGenerationPolicy {
+
+    public FifthGenerationCoverageRuleGenerationPolicy() {
+        super(
+                InsuranceGeneration.FIFTH,
+                70,
+                10000,
+                60,
+                30000,
+                "5세대 실손보험 임시 정책 기준입니다."
+        );
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/FirstGenerationCoverageRuleGenerationPolicy.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/FirstGenerationCoverageRuleGenerationPolicy.java
@@ -1,0 +1,24 @@
+package com.silsonfit.silsonfit_api.domain.calculation.policy;
+
+import com.silsonfit.silsonfit_api.domain.calculation.enums.InsuranceGeneration;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * 1세대 실손보험 보장 룰 생성 정책
+ */
+@Component
+@Order(100)
+public class FirstGenerationCoverageRuleGenerationPolicy extends AbstractCoverageRuleGenerationPolicy {
+
+    public FirstGenerationCoverageRuleGenerationPolicy() {
+        super(
+                InsuranceGeneration.FIRST,
+                100,
+                0,
+                100,
+                0,
+                "1세대 실손보험은 급여/비급여 대부분을 보장하며 자기부담금이 거의 없는 한도 중심 임시 정책 기준입니다."
+        );
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/FourthGenerationCoverageRuleGenerationPolicy.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/FourthGenerationCoverageRuleGenerationPolicy.java
@@ -2,7 +2,7 @@ package com.silsonfit.silsonfit_api.domain.calculation.policy;
 
 import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.InsuranceGeneration;
-import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleGenerationContext;
+import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleContext;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -30,7 +30,7 @@ public class FourthGenerationCoverageRuleGenerationPolicy extends AbstractCovera
     }
 
     @Override
-    public String disclaimer(CoverageRuleGenerationContext context, EdiCode ediCode) {
+    public String disclaimer(CoverageRuleContext context, EdiCode ediCode) {
         if (!ediCode.isPay()) {
             return "4세대 실손보험 비급여는 특약 분리 및 이용량 기반 보험료 차등 대상이며, 연간 비급여 사용량 집계가 필요한 임시 정책 기준입니다.";
         }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/FourthGenerationCoverageRuleGenerationPolicy.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/FourthGenerationCoverageRuleGenerationPolicy.java
@@ -1,0 +1,40 @@
+package com.silsonfit.silsonfit_api.domain.calculation.policy;
+
+import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.InsuranceGeneration;
+import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleGenerationContext;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * 4세대 실손보험 보장 룰 생성 정책
+ *
+ * - 급여 기본계약 + 비급여 특약 구조를 유지한다.
+ * - 비급여 이용량을 기반으로 보험료를 차등 적용하는 행동 기반 구조다.
+ * TODO(calculation): UsageHistory/AnnualAggregation/PremiumAdjustment 도메인 추가 후
+ *  annualNonCoveredUsage 기반 보험료 할인/유지/할증 정책을 연결한다.
+ */
+@Component
+@Order(100)
+public class FourthGenerationCoverageRuleGenerationPolicy extends AbstractCoverageRuleGenerationPolicy {
+
+    public FourthGenerationCoverageRuleGenerationPolicy() {
+        super(
+                InsuranceGeneration.FOURTH,
+                80,
+                10000,
+                70,
+                30000,
+                "4세대 실손보험은 급여 20%, 비급여 30% 수준의 자기부담과 비급여 이용량 기반 보험료 차등을 전제로 한 임시 정책 기준입니다."
+        );
+    }
+
+    @Override
+    public String disclaimer(CoverageRuleGenerationContext context, EdiCode ediCode) {
+        if (!ediCode.isPay()) {
+            return "4세대 실손보험 비급여는 특약 분리 및 이용량 기반 보험료 차등 대상이며, 연간 비급여 사용량 집계가 필요한 임시 정책 기준입니다.";
+        }
+
+        return super.disclaimer(context, ediCode);
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/SecondGenerationCoverageRuleGenerationPolicy.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/SecondGenerationCoverageRuleGenerationPolicy.java
@@ -1,0 +1,27 @@
+package com.silsonfit.silsonfit_api.domain.calculation.policy;
+
+import com.silsonfit.silsonfit_api.domain.calculation.enums.InsuranceGeneration;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * 2세대 실손보험 보장 룰 생성 정책
+ *
+ * - 자기부담금이 도입된 표준화 실손 구조
+ * - 급여는 약 10%, 비급여는 약 20% 수준의 자기부담을 적용한다.
+ */
+@Component
+@Order(100)
+public class SecondGenerationCoverageRuleGenerationPolicy extends AbstractCoverageRuleGenerationPolicy {
+
+    public SecondGenerationCoverageRuleGenerationPolicy() {
+        super(
+                InsuranceGeneration.SECOND,
+                90,
+                10000,
+                80,
+                20000,
+                "2세대 실손보험은 표준화 이후 급여/비급여 보장을 유지하되 자기부담 10~20%를 적용하는 임시 정책 기준입니다."
+        );
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/ThirdGenerationCoverageRuleGenerationPolicy.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/ThirdGenerationCoverageRuleGenerationPolicy.java
@@ -2,7 +2,7 @@ package com.silsonfit.silsonfit_api.domain.calculation.policy;
 
 import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.InsuranceGeneration;
-import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleGenerationContext;
+import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleContext;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -28,7 +28,7 @@ public class ThirdGenerationCoverageRuleGenerationPolicy extends AbstractCoverag
     }
 
     @Override
-    public String disclaimer(CoverageRuleGenerationContext context, EdiCode ediCode) {
+    public String disclaimer(CoverageRuleContext context, EdiCode ediCode) {
         if (!ediCode.isPay()) {
             return "3세대 실손보험 비급여는 특약 분리 항목으로, 특약 가입 및 항목별 한도 확인이 필요한 임시 정책 기준입니다.";
         }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/ThirdGenerationCoverageRuleGenerationPolicy.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/policy/ThirdGenerationCoverageRuleGenerationPolicy.java
@@ -1,0 +1,38 @@
+package com.silsonfit.silsonfit_api.domain.calculation.policy;
+
+import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.InsuranceGeneration;
+import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleGenerationContext;
+import org.springframework.core.annotation.Order;
+import org.springframework.stereotype.Component;
+
+/**
+ * 3세대 실손보험 보장 룰 생성 정책
+ *
+ * - 급여는 기본계약, 비급여는 특약으로 분리된 구조
+ * - 비급여는 특약 가입 여부와 항목별 제한을 확인해야 하지만, 현재는 특약 가입을 전제로 한 임시 기준을 적용한다.
+ */
+@Component
+@Order(100)
+public class ThirdGenerationCoverageRuleGenerationPolicy extends AbstractCoverageRuleGenerationPolicy {
+
+    public ThirdGenerationCoverageRuleGenerationPolicy() {
+        super(
+                InsuranceGeneration.THIRD,
+                80,
+                10000,
+                70,
+                30000,
+                "3세대 실손보험은 급여 기본계약과 비급여 특약을 분리하며, 현재는 비급여 특약 가입을 전제로 한 임시 정책 기준입니다."
+        );
+    }
+
+    @Override
+    public String disclaimer(CoverageRuleGenerationContext context, EdiCode ediCode) {
+        if (!ediCode.isPay()) {
+            return "3세대 실손보험 비급여는 특약 분리 항목으로, 특약 가입 및 항목별 한도 확인이 필요한 임시 정책 기준입니다.";
+        }
+
+        return super.disclaimer(context, ediCode);
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationService.java
@@ -4,8 +4,10 @@ import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationRequest;
 import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationResponse;
 import com.silsonfit.silsonfit_api.domain.calculation.entity.CalculationHistory;
 import com.silsonfit.silsonfit_api.domain.calculation.entity.CoverageRule;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.InsuranceGeneration;
 import com.silsonfit.silsonfit_api.domain.calculation.repository.CalculationHistoryRepository;
 import com.silsonfit.silsonfit_api.domain.calculation.vo.CalculationResult;
+import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -35,8 +37,14 @@ public class CalculationService {
      */
     @Transactional
     public CalculationResponse calculate(Long userId, CalculationRequest request) {
-        CoverageRule coverageRule = coverageRuleResolver.resolve(
+        // TODO(calculation): 보험 도메인 연동 후 insuranceId 기반 보험 세대/약관 조회로 대체한다.
+        CoverageRuleContext context = new CoverageRuleContext(
                 request.getInsuranceId(),
+                InsuranceGeneration.FOURTH
+        );
+
+        CoverageRule coverageRule = coverageRuleResolver.resolve(
+                context,
                 request.getEdiCode(),
                 request.getVisitType(),
                 request.getTreatmentCategory(),

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleGenerationPolicyResolver.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleGenerationPolicyResolver.java
@@ -1,0 +1,36 @@
+package com.silsonfit.silsonfit_api.domain.calculation.service;
+
+import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
+import com.silsonfit.silsonfit_api.domain.calculation.policy.CoverageRuleGenerationPolicy;
+import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleGenerationContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+/**
+ * 보장 룰 생성 정책 Resolver
+ *
+ * - 보험 세대, 보험 ID, EDI 코드 조건을 만족하는 정책을 선택한다.
+ * - 구체적인 정책을 높은 우선순위로 등록하면 기본 세대별 정책보다 먼저 적용된다.
+ */
+@Component
+@RequiredArgsConstructor
+public class CoverageRuleGenerationPolicyResolver {
+
+    private final List<CoverageRuleGenerationPolicy> policies;
+
+    /**
+     * 보장 룰 생성 정책 조회
+     *
+     * @param context 보험 조건
+     * @param ediCode EDI 코드
+     * @return 적용할 보장 룰 생성 정책
+     */
+    public CoverageRuleGenerationPolicy resolve(CoverageRuleGenerationContext context, EdiCode ediCode) {
+        return policies.stream()
+                .filter(policy -> policy.supports(context, ediCode))
+                .findFirst()
+                .orElseThrow(() -> new IllegalArgumentException("적용 가능한 보장 룰 생성 정책이 없습니다: " + context.generation()));
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleGenerationPolicyResolver.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleGenerationPolicyResolver.java
@@ -2,7 +2,7 @@ package com.silsonfit.silsonfit_api.domain.calculation.service;
 
 import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
 import com.silsonfit.silsonfit_api.domain.calculation.policy.CoverageRuleGenerationPolicy;
-import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleGenerationContext;
+import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -27,7 +27,7 @@ public class CoverageRuleGenerationPolicyResolver {
      * @param ediCode EDI 코드
      * @return 적용할 보장 룰 생성 정책
      */
-    public CoverageRuleGenerationPolicy resolve(CoverageRuleGenerationContext context, EdiCode ediCode) {
+    public CoverageRuleGenerationPolicy resolve(CoverageRuleContext context, EdiCode ediCode) {
         return policies.stream()
                 .filter(policy -> policy.supports(context, ediCode))
                 .findFirst()

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleGenerator.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleGenerator.java
@@ -1,0 +1,134 @@
+package com.silsonfit.silsonfit_api.domain.calculation.service;
+
+import com.silsonfit.silsonfit_api.domain.calculation.entity.CoverageRule;
+import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.FeeType;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.PurposeType;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.VisitType;
+import com.silsonfit.silsonfit_api.domain.calculation.policy.CoverageRuleGenerationPolicy;
+import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleGenerationContext;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+/**
+ * 보장 룰 생성기
+ *
+ * - 외부 수가 API 응답을 저장한 EDI 코드 정보를 기반으로 보장 룰을 생성한다.
+ * - 보험 세대/보험 ID별 보장 정책은 CoverageRuleGenerationPolicy 구현체가 결정한다.
+ * TODO(calculation): 실제 보험 약관 DB가 생기면 CoverageRuleGenerationPolicy 구현체에서 DB 정책을 조회하도록 확장한다.
+ */
+@Component
+@RequiredArgsConstructor
+public class CoverageRuleGenerator {
+
+    private final CoverageRuleGenerationPolicyResolver policyResolver;
+
+    /**
+     * EDI 코드 기반 기본 보장 룰 생성
+     *
+     * @param context 보험 조건
+     * @param ediCode EDI 코드
+     * @return 생성된 보장 룰
+     */
+    public CoverageRule generate(
+            CoverageRuleGenerationContext context,
+            EdiCode ediCode
+    ) {
+        CoverageRuleGenerationPolicy policy = policyResolver.resolve(context, ediCode);
+        boolean isCovered = policy.isCovered(context, ediCode);
+
+        return CoverageRule.create(
+                context.insuranceId(),
+                ediCode.getCode(),
+                resolveVisitType(ediCode),
+                resolveTreatmentCategory(ediCode),
+                resolvePurposeType(ediCode),
+                isCovered,
+                policy.coverageRate(context, ediCode),
+                policy.deductibleAmount(context, ediCode),
+                policy.limitAmount(context, ediCode),
+                createBasis(context, ediCode, isCovered),
+                policy.disclaimer(context, ediCode)
+        );
+    }
+
+    /**
+     * EDI 수가 유형 기반 진료 유형 결정
+     */
+    private VisitType resolveVisitType(EdiCode ediCode) {
+        if (ediCode.getFeeType() == FeeType.PHARMACY) {
+            return VisitType.MEDICATION;
+        }
+
+        return VisitType.OUTPATIENT;
+    }
+
+    /**
+     * EDI 명칭/분류번호 기반 진료 항목 결정
+     */
+    private TreatmentCategory resolveTreatmentCategory(EdiCode ediCode) {
+        if (ediCode.containsKeyword("MRI") || ediCode.containsKeyword("자기공명")) {
+            return TreatmentCategory.MRI;
+        }
+        if (ediCode.containsKeyword("CT") || ediCode.containsKeyword("전산화단층")) {
+            return TreatmentCategory.CT;
+        }
+        if (ediCode.containsKeyword("도수")) {
+            return TreatmentCategory.MANUAL_THERAPY;
+        }
+        if (ediCode.containsKeyword("충격파")) {
+            return TreatmentCategory.SHOCKWAVE_THERAPY;
+        }
+        if (ediCode.containsKeyword("주사")) {
+            return TreatmentCategory.INJECTION;
+        }
+        if (ediCode.containsKeyword("물리")) {
+            return TreatmentCategory.PHYSICAL_THERAPY;
+        }
+
+        return TreatmentCategory.GENERAL_TREATMENT;
+    }
+
+    /**
+     * EDI 명칭 기반 진료 목적 결정
+     */
+    private PurposeType resolvePurposeType(EdiCode ediCode) {
+        if (ediCode.containsKeyword("검진") || ediCode.containsKeyword("건강검진")) {
+            return PurposeType.CHECKUP;
+        }
+
+        return PurposeType.TREATMENT;
+    }
+
+    /**
+     * EDI 코드 원본 응답 필드를 계산 근거로 생성
+     */
+    private String createBasis(
+            CoverageRuleGenerationContext context,
+            EdiCode ediCode,
+            boolean isCovered
+    ) {
+        return String.format(
+                "보험세대 %s, EDI 코드 %s, 한글명 %s, 수가분류번호 %s, 급여구분 %s, 수가유형 %s, 단가 %s원, 상대가치점수 %s, 적용시작일자 %s, 보장여부 %s 기준 보장 룰",
+                context.generation().getDescription(),
+                ediCode.getCode(),
+                ediCode.getTreatmentName(),
+                formatNullable(ediCode.getFeeDivisionNumber()),
+                ediCode.getPayType().getDescription(),
+                ediCode.getFeeType().getDescription(),
+                formatNullable(ediCode.getUnitPrice()),
+                formatNullable(ediCode.getRelativeValuePoint()),
+                formatNullable(ediCode.getEffectiveStartDate()),
+                isCovered ? "보장" : "비보장"
+        );
+    }
+
+    private String formatNullable(Object value) {
+        if (value == null) {
+            return "-";
+        }
+
+        return value.toString();
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleGenerator.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleGenerator.java
@@ -7,7 +7,7 @@ import com.silsonfit.silsonfit_api.domain.calculation.enums.PurposeType;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.VisitType;
 import com.silsonfit.silsonfit_api.domain.calculation.policy.CoverageRuleGenerationPolicy;
-import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleGenerationContext;
+import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleContext;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
 
@@ -32,7 +32,7 @@ public class CoverageRuleGenerator {
      * @return 생성된 보장 룰
      */
     public CoverageRule generate(
-            CoverageRuleGenerationContext context,
+            CoverageRuleContext context,
             EdiCode ediCode
     ) {
         CoverageRuleGenerationPolicy policy = policyResolver.resolve(context, ediCode);
@@ -105,7 +105,7 @@ public class CoverageRuleGenerator {
      * EDI 코드 원본 응답 필드를 계산 근거로 생성
      */
     private String createBasis(
-            CoverageRuleGenerationContext context,
+            CoverageRuleContext context,
             EdiCode ediCode,
             boolean isCovered
     ) {

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleResolver.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleResolver.java
@@ -1,32 +1,39 @@
 package com.silsonfit.silsonfit_api.domain.calculation.service;
 
 import com.silsonfit.silsonfit_api.domain.calculation.entity.CoverageRule;
+import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.PurposeType;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.VisitType;
 import com.silsonfit.silsonfit_api.domain.calculation.repository.CoverageRuleRepository;
+import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleContext;
 import com.silsonfit.silsonfit_api.global.error.BusinessException;
 import com.silsonfit.silsonfit_api.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
 
 /**
  * 보장 룰 조회 Resolver
  *
  * - EDI 코드가 있으면 보험 ID + EDI 코드 기반 룰을 우선 조회한다.
- * - EDI 코드가 없거나 EDI 기반 룰이 없으면 진료 유형/항목/목적 기반 룰로 대체 조회한다.
+ * - EDI 기반 룰이 없으면 EDI 코드 정보와 보험 정책으로 보장 룰을 생성한다.
+ * - EDI 코드가 없으면 진료 유형/항목/목적 기반 룰로 대체 조회한다.
  */
 @Service
 @RequiredArgsConstructor
+@Transactional
 public class CoverageRuleResolver {
 
     private final CoverageRuleRepository coverageRuleRepository;
+    private final EdiCodeResolver ediCodeResolver;
+    private final CoverageRuleGenerator coverageRuleGenerator;
 
     /**
      * 계산 요청 조건에 맞는 보장 룰 조회
      *
-     * @param insuranceId 보험 ID
+     * @param context 보장 룰 생성 Context
      * @param ediCode EDI 코드
      * @param visitType 진료 유형
      * @param treatmentCategory 진료 항목
@@ -34,24 +41,19 @@ public class CoverageRuleResolver {
      * @return 계산에 사용할 보장 룰
      */
     public CoverageRule resolve(
-            Long insuranceId,
+            CoverageRuleContext context,
             String ediCode,
             VisitType visitType,
             TreatmentCategory treatmentCategory,
             PurposeType purposeType
     ) {
+        Long insuranceId = context.insuranceId();
+
         if (StringUtils.hasText(ediCode)) {
-            return coverageRuleRepository.findByInsuranceIdAndEdiCode(insuranceId, ediCode.trim())
-                    // TODO(calculation): EDI 기반 CoverageRule이 없으면 EdiCodeResolver로 EDI 정보를 조회한다.
-                    //  - DB에 EDI 코드가 없으면 공공 EDI API client로 조회 후 edi_code에 저장한다.
-                    //  - 보험 ID로 보험 세대/약관 정보를 조회해 CoverageRuleGenerationContext를 만든다.
-                    //  - CoverageRuleGenerator로 EDI + 보험 정책 기반 CoverageRule을 생성하고 저장한 뒤 반환한다.
-                    .orElseGet(() -> resolveByTreatmentInfo(
-                            insuranceId,
-                            visitType,
-                            treatmentCategory,
-                            purposeType
-                    ));
+            String normalizedEdiCode = ediCode.trim();
+
+            return coverageRuleRepository.findByInsuranceIdAndEdiCode(insuranceId, normalizedEdiCode)
+                    .orElseGet(() -> generateAndSaveByEdiCode(context, normalizedEdiCode));
         }
 
         return resolveByTreatmentInfo(
@@ -60,6 +62,19 @@ public class CoverageRuleResolver {
                 treatmentCategory,
                 purposeType
         );
+    }
+
+    /**
+     * EDI 코드 정보 기반 보장 룰 생성 후 저장
+     */
+    private CoverageRule generateAndSaveByEdiCode(
+            CoverageRuleContext context,
+            String ediCode
+    ) {
+        EdiCode resolvedEdiCode = ediCodeResolver.resolve(ediCode);
+        CoverageRule generatedRule = coverageRuleGenerator.generate(context, resolvedEdiCode);
+
+        return coverageRuleRepository.save(generatedRule);
     }
 
     /**

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleResolver.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleResolver.java
@@ -42,6 +42,10 @@ public class CoverageRuleResolver {
     ) {
         if (StringUtils.hasText(ediCode)) {
             return coverageRuleRepository.findByInsuranceIdAndEdiCode(insuranceId, ediCode.trim())
+                    // TODO(calculation): EDI 기반 CoverageRule이 없으면 EdiCodeResolver로 EDI 정보를 조회한다.
+                    //  - DB에 EDI 코드가 없으면 공공 EDI API client로 조회 후 edi_code에 저장한다.
+                    //  - 보험 ID로 보험 세대/약관 정보를 조회해 CoverageRuleGenerationContext를 만든다.
+                    //  - CoverageRuleGenerator로 EDI + 보험 정책 기반 CoverageRule을 생성하고 저장한 뒤 반환한다.
                     .orElseGet(() -> resolveByTreatmentInfo(
                             insuranceId,
                             visitType,

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/EdiCodeResolver.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/EdiCodeResolver.java
@@ -34,6 +34,10 @@ public class EdiCodeResolver {
         }
 
         return ediCodeRepository.findByCode(code.trim())
+                // TODO(calculation): DB에 없는 EDI 코드는 외부 조회 흐름으로 확장한다.
+                //  - EdiCodeClient 인터페이스를 만들고 fake 구현체를 먼저 붙인다.
+                //  - 실제 공공 API 연동 시 한방수가/진료수가/약국수가 응답을 EdiCode 필드로 매핑한다.
+                //  - 조회 성공 시 edi_code 테이블에 저장한 뒤 반환한다.
                 .orElseThrow(() -> new BusinessException(ErrorCode.EDI_CODE_NOT_FOUND));
     }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/EdiCodeResolver.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/EdiCodeResolver.java
@@ -1,5 +1,6 @@
 package com.silsonfit.silsonfit_api.domain.calculation.service;
 
+import com.silsonfit.silsonfit_api.domain.calculation.client.EdiCodeClient;
 import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
 import com.silsonfit.silsonfit_api.domain.calculation.repository.EdiCodeRepository;
 import com.silsonfit.silsonfit_api.global.error.BusinessException;
@@ -13,14 +14,14 @@ import org.springframework.util.StringUtils;
  * EDI 코드 조회 Resolver
  *
  * - 우선 DB에 저장된 EDI 수가 코드를 조회한다.
- * - DB에 없는 경우 추후 공공 API 조회 로직으로 확장한다.
+ * - DB에 없는 경우 외부 EDI 수가 코드 Client로 조회 후 저장한다.
  */
 @Service
 @RequiredArgsConstructor
-@Transactional(readOnly = true)
 public class EdiCodeResolver {
 
     private final EdiCodeRepository ediCodeRepository;
+    private final EdiCodeClient ediCodeClient;
 
     /**
      * 수가 코드에 해당하는 EDI 코드 조회
@@ -28,16 +29,25 @@ public class EdiCodeResolver {
      * @param code 수가 코드
      * @return EDI 코드
      */
+    @Transactional
     public EdiCode resolve(String code) {
         if (!StringUtils.hasText(code)) {
             throw new BusinessException(ErrorCode.EDI_CODE_NOT_FOUND);
         }
 
-        return ediCodeRepository.findByCode(code.trim())
-                // TODO(calculation): DB에 없는 EDI 코드는 외부 조회 흐름으로 확장한다.
-                //  - EdiCodeClient 인터페이스를 만들고 fake 구현체를 먼저 붙인다.
-                //  - 실제 공공 API 연동 시 한방수가/진료수가/약국수가 응답을 EdiCode 필드로 매핑한다.
-                //  - 조회 성공 시 edi_code 테이블에 저장한 뒤 반환한다.
+        String normalizedCode = code.trim();
+
+        return ediCodeRepository.findByCode(normalizedCode)
+                .orElseGet(() -> fetchAndSave(normalizedCode));
+    }
+
+    /**
+     * 외부 EDI Client 조회 후 저장
+     */
+    private EdiCode fetchAndSave(String code) {
+        EdiCode fetchedEdiCode = ediCodeClient.fetchByCode(code)
                 .orElseThrow(() -> new BusinessException(ErrorCode.EDI_CODE_NOT_FOUND));
+
+        return ediCodeRepository.save(fetchedEdiCode);
     }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/vo/CoverageRuleContext.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/vo/CoverageRuleContext.java
@@ -3,12 +3,12 @@ package com.silsonfit.silsonfit_api.domain.calculation.vo;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.InsuranceGeneration;
 
 /**
- * 보장 룰 생성에 필요한 보험 조건
+ * 보장 룰 조회/생성에 필요한 보험 조건
  *
  * - 보험 도메인 연동 전까지 계산 도메인에서 필요한 최소 보험 정보를 담는다.
  * - 이후 보험 엔티티/약관 정보가 추가되면 이 Context를 확장하거나 대체한다.
  */
-public record CoverageRuleGenerationContext(
+public record CoverageRuleContext(
         Long insuranceId,
         InsuranceGeneration generation
 ) {

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/vo/CoverageRuleGenerationContext.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/vo/CoverageRuleGenerationContext.java
@@ -1,0 +1,15 @@
+package com.silsonfit.silsonfit_api.domain.calculation.vo;
+
+import com.silsonfit.silsonfit_api.domain.calculation.enums.InsuranceGeneration;
+
+/**
+ * 보장 룰 생성에 필요한 보험 조건
+ *
+ * - 보험 도메인 연동 전까지 계산 도메인에서 필요한 최소 보험 정보를 담는다.
+ * - 이후 보험 엔티티/약관 정보가 추가되면 이 Context를 확장하거나 대체한다.
+ */
+public record CoverageRuleGenerationContext(
+        Long insuranceId,
+        InsuranceGeneration generation
+) {
+}

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleGeneratorTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleGeneratorTest.java
@@ -12,7 +12,7 @@ import com.silsonfit.silsonfit_api.domain.calculation.policy.FirstGenerationCove
 import com.silsonfit.silsonfit_api.domain.calculation.policy.FourthGenerationCoverageRuleGenerationPolicy;
 import com.silsonfit.silsonfit_api.domain.calculation.policy.SecondGenerationCoverageRuleGenerationPolicy;
 import com.silsonfit.silsonfit_api.domain.calculation.policy.ThirdGenerationCoverageRuleGenerationPolicy;
-import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleGenerationContext;
+import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleContext;
 import org.junit.jupiter.api.Test;
 
 import java.math.BigDecimal;
@@ -32,7 +32,7 @@ class CoverageRuleGeneratorTest {
                     new FifthGenerationCoverageRuleGenerationPolicy()
             ))
     );
-    CoverageRuleGenerationContext context = new CoverageRuleGenerationContext(1L, InsuranceGeneration.FOURTH);
+    CoverageRuleContext context = new CoverageRuleContext(1L, InsuranceGeneration.FOURTH);
 
     @Test
     void 급여_EDI코드는_급여_기본_보장룰을_생성한다() {
@@ -102,10 +102,10 @@ class CoverageRuleGeneratorTest {
     @Test
     void 보험_세대별_정책값을_다르게_적용한다() {
         EdiCode ediCode = createEdiCode("EDI005", "일반 진료", "일반", PayType.NON_PAY, FeeType.MEDICAL);
-        CoverageRuleGenerationContext firstGenerationContext =
-                new CoverageRuleGenerationContext(1L, InsuranceGeneration.FIRST);
-        CoverageRuleGenerationContext fifthGenerationContext =
-                new CoverageRuleGenerationContext(1L, InsuranceGeneration.FIFTH);
+        CoverageRuleContext firstGenerationContext =
+                new CoverageRuleContext(1L, InsuranceGeneration.FIRST);
+        CoverageRuleContext fifthGenerationContext =
+                new CoverageRuleContext(1L, InsuranceGeneration.FIFTH);
 
         CoverageRule firstGenerationRule = coverageRuleGenerator.generate(firstGenerationContext, ediCode);
         CoverageRule fifthGenerationRule = coverageRuleGenerator.generate(fifthGenerationContext, ediCode);
@@ -122,8 +122,8 @@ class CoverageRuleGeneratorTest {
     void 이세대는_급여_10퍼센트_비급여_20퍼센트_자기부담_구조를_적용한다() {
         EdiCode payEdiCode = createEdiCode("EDI006", "외래 진료", "일반", PayType.PAY, FeeType.MEDICAL);
         EdiCode nonPayEdiCode = createEdiCode("EDI007", "비급여 도수치료", "도수", PayType.NON_PAY, FeeType.MEDICAL);
-        CoverageRuleGenerationContext secondGenerationContext =
-                new CoverageRuleGenerationContext(1L, InsuranceGeneration.SECOND);
+        CoverageRuleContext secondGenerationContext =
+                new CoverageRuleContext(1L, InsuranceGeneration.SECOND);
 
         CoverageRule payRule = coverageRuleGenerator.generate(secondGenerationContext, payEdiCode);
         CoverageRule nonPayRule = coverageRuleGenerator.generate(secondGenerationContext, nonPayEdiCode);
@@ -139,8 +139,8 @@ class CoverageRuleGeneratorTest {
     void 삼세대는_비급여를_특약_분리_항목으로_처리한다() {
         EdiCode payEdiCode = createEdiCode("EDI008", "외래 진료", "일반", PayType.PAY, FeeType.MEDICAL);
         EdiCode nonPayEdiCode = createEdiCode("EDI009", "비급여 MRI 검사", "MRI", PayType.NON_PAY, FeeType.MEDICAL);
-        CoverageRuleGenerationContext thirdGenerationContext =
-                new CoverageRuleGenerationContext(1L, InsuranceGeneration.THIRD);
+        CoverageRuleContext thirdGenerationContext =
+                new CoverageRuleContext(1L, InsuranceGeneration.THIRD);
 
         CoverageRule payRule = coverageRuleGenerator.generate(thirdGenerationContext, payEdiCode);
         CoverageRule nonPayRule = coverageRuleGenerator.generate(thirdGenerationContext, nonPayEdiCode);
@@ -157,8 +157,8 @@ class CoverageRuleGeneratorTest {
     void 사세대는_비급여_이용량_기반_보험료_차등_대상임을_표시한다() {
         EdiCode payEdiCode = createEdiCode("EDI010", "외래 진료", "일반", PayType.PAY, FeeType.MEDICAL);
         EdiCode nonPayEdiCode = createEdiCode("EDI011", "비급여 주사 치료", "주사", PayType.NON_PAY, FeeType.MEDICAL);
-        CoverageRuleGenerationContext fourthGenerationContext =
-                new CoverageRuleGenerationContext(1L, InsuranceGeneration.FOURTH);
+        CoverageRuleContext fourthGenerationContext =
+                new CoverageRuleContext(1L, InsuranceGeneration.FOURTH);
 
         CoverageRule payRule = coverageRuleGenerator.generate(fourthGenerationContext, payEdiCode);
         CoverageRule nonPayRule = coverageRuleGenerator.generate(fourthGenerationContext, nonPayEdiCode);

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleGeneratorTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleGeneratorTest.java
@@ -1,0 +1,192 @@
+package com.silsonfit.silsonfit_api.domain.calculation.service;
+
+import com.silsonfit.silsonfit_api.domain.calculation.entity.CoverageRule;
+import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.FeeType;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.InsuranceGeneration;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.PayType;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.VisitType;
+import com.silsonfit.silsonfit_api.domain.calculation.policy.FifthGenerationCoverageRuleGenerationPolicy;
+import com.silsonfit.silsonfit_api.domain.calculation.policy.FirstGenerationCoverageRuleGenerationPolicy;
+import com.silsonfit.silsonfit_api.domain.calculation.policy.FourthGenerationCoverageRuleGenerationPolicy;
+import com.silsonfit.silsonfit_api.domain.calculation.policy.SecondGenerationCoverageRuleGenerationPolicy;
+import com.silsonfit.silsonfit_api.domain.calculation.policy.ThirdGenerationCoverageRuleGenerationPolicy;
+import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleGenerationContext;
+import org.junit.jupiter.api.Test;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CoverageRuleGeneratorTest {
+
+    CoverageRuleGenerator coverageRuleGenerator = new CoverageRuleGenerator(
+            new CoverageRuleGenerationPolicyResolver(List.of(
+                    new FirstGenerationCoverageRuleGenerationPolicy(),
+                    new SecondGenerationCoverageRuleGenerationPolicy(),
+                    new ThirdGenerationCoverageRuleGenerationPolicy(),
+                    new FourthGenerationCoverageRuleGenerationPolicy(),
+                    new FifthGenerationCoverageRuleGenerationPolicy()
+            ))
+    );
+    CoverageRuleGenerationContext context = new CoverageRuleGenerationContext(1L, InsuranceGeneration.FOURTH);
+
+    @Test
+    void 급여_EDI코드는_급여_기본_보장룰을_생성한다() {
+        EdiCode ediCode = createEdiCode("EDI001", "MRI 검사", "MRI", PayType.PAY, FeeType.MEDICAL);
+
+        CoverageRule coverageRule = coverageRuleGenerator.generate(
+                context,
+                ediCode
+        );
+
+        assertThat(coverageRule.getEdiCode()).isEqualTo("EDI001");
+        assertThat(coverageRule.getVisitType()).isEqualTo(VisitType.OUTPATIENT);
+        assertThat(coverageRule.getTreatmentCategory()).isEqualTo(TreatmentCategory.MRI);
+        assertThat(coverageRule.getCoverageRate()).isEqualTo(80);
+        assertThat(coverageRule.getDeductibleAmount()).isEqualTo(10000);
+        assertThat(coverageRule.getLimitAmount()).isEqualTo(100000);
+        assertThat(coverageRule.getIsCovered()).isTrue();
+        assertThat(coverageRule.getBasis())
+                .contains("4세대", "EDI001", "MRI 검사", "MRI", "급여", "진료수가", "100000", "123.45", "2026-01-01", "보장");
+    }
+
+    @Test
+    void 비급여_EDI코드는_비급여_기본_보장룰을_생성한다() {
+        EdiCode ediCode = createEdiCode("EDI002", "도수치료", "도수", PayType.NON_PAY, FeeType.MEDICAL);
+
+        CoverageRule coverageRule = coverageRuleGenerator.generate(
+                context,
+                ediCode
+        );
+
+        assertThat(coverageRule.getEdiCode()).isEqualTo("EDI002");
+        assertThat(coverageRule.getTreatmentCategory()).isEqualTo(TreatmentCategory.MANUAL_THERAPY);
+        assertThat(coverageRule.getCoverageRate()).isEqualTo(70);
+        assertThat(coverageRule.getDeductibleAmount()).isEqualTo(30000);
+        assertThat(coverageRule.getLimitAmount()).isEqualTo(100000);
+        assertThat(coverageRule.getBasis()).contains("EDI002", "도수치료", "도수", "비급여", "진료수가");
+    }
+
+    @Test
+    void 약국_EDI코드는_약제_진료유형으로_생성한다() {
+        EdiCode ediCode = createEdiCode("EDI003", "처방 조제", "약국", PayType.PAY, FeeType.PHARMACY);
+
+        CoverageRule coverageRule = coverageRuleGenerator.generate(
+                context,
+                ediCode
+        );
+
+        assertThat(coverageRule.getVisitType()).isEqualTo(VisitType.MEDICATION);
+        assertThat(coverageRule.getTreatmentCategory()).isEqualTo(TreatmentCategory.GENERAL_TREATMENT);
+    }
+
+    @Test
+    void 검진_EDI코드는_비보장_보장룰을_생성한다() {
+        EdiCode ediCode = createEdiCode("EDI004", "건강검진 검사", "검진", PayType.PAY, FeeType.MEDICAL);
+
+        CoverageRule coverageRule = coverageRuleGenerator.generate(
+                context,
+                ediCode
+        );
+
+        assertThat(coverageRule.getIsCovered()).isFalse();
+        assertThat(coverageRule.getCoverageRate()).isZero();
+        assertThat(coverageRule.getDeductibleAmount()).isZero();
+        assertThat(coverageRule.getBasis()).contains("건강검진 검사", "비보장");
+    }
+
+    @Test
+    void 보험_세대별_정책값을_다르게_적용한다() {
+        EdiCode ediCode = createEdiCode("EDI005", "일반 진료", "일반", PayType.NON_PAY, FeeType.MEDICAL);
+        CoverageRuleGenerationContext firstGenerationContext =
+                new CoverageRuleGenerationContext(1L, InsuranceGeneration.FIRST);
+        CoverageRuleGenerationContext fifthGenerationContext =
+                new CoverageRuleGenerationContext(1L, InsuranceGeneration.FIFTH);
+
+        CoverageRule firstGenerationRule = coverageRuleGenerator.generate(firstGenerationContext, ediCode);
+        CoverageRule fifthGenerationRule = coverageRuleGenerator.generate(fifthGenerationContext, ediCode);
+
+        assertThat(firstGenerationRule.getCoverageRate()).isEqualTo(100);
+        assertThat(firstGenerationRule.getDeductibleAmount()).isZero();
+        assertThat(firstGenerationRule.getDisclaimer()).contains("1세대", "급여/비급여 대부분", "자기부담금이 거의 없는", "한도 중심");
+        assertThat(fifthGenerationRule.getCoverageRate()).isEqualTo(60);
+        assertThat(fifthGenerationRule.getDeductibleAmount()).isEqualTo(30000);
+        assertThat(fifthGenerationRule.getDisclaimer()).contains("5세대");
+    }
+
+    @Test
+    void 이세대는_급여_10퍼센트_비급여_20퍼센트_자기부담_구조를_적용한다() {
+        EdiCode payEdiCode = createEdiCode("EDI006", "외래 진료", "일반", PayType.PAY, FeeType.MEDICAL);
+        EdiCode nonPayEdiCode = createEdiCode("EDI007", "비급여 도수치료", "도수", PayType.NON_PAY, FeeType.MEDICAL);
+        CoverageRuleGenerationContext secondGenerationContext =
+                new CoverageRuleGenerationContext(1L, InsuranceGeneration.SECOND);
+
+        CoverageRule payRule = coverageRuleGenerator.generate(secondGenerationContext, payEdiCode);
+        CoverageRule nonPayRule = coverageRuleGenerator.generate(secondGenerationContext, nonPayEdiCode);
+
+        assertThat(payRule.getCoverageRate()).isEqualTo(90);
+        assertThat(payRule.getDeductibleAmount()).isEqualTo(10000);
+        assertThat(nonPayRule.getCoverageRate()).isEqualTo(80);
+        assertThat(nonPayRule.getDeductibleAmount()).isEqualTo(20000);
+        assertThat(nonPayRule.getDisclaimer()).contains("2세대", "표준화", "자기부담 10~20%");
+    }
+
+    @Test
+    void 삼세대는_비급여를_특약_분리_항목으로_처리한다() {
+        EdiCode payEdiCode = createEdiCode("EDI008", "외래 진료", "일반", PayType.PAY, FeeType.MEDICAL);
+        EdiCode nonPayEdiCode = createEdiCode("EDI009", "비급여 MRI 검사", "MRI", PayType.NON_PAY, FeeType.MEDICAL);
+        CoverageRuleGenerationContext thirdGenerationContext =
+                new CoverageRuleGenerationContext(1L, InsuranceGeneration.THIRD);
+
+        CoverageRule payRule = coverageRuleGenerator.generate(thirdGenerationContext, payEdiCode);
+        CoverageRule nonPayRule = coverageRuleGenerator.generate(thirdGenerationContext, nonPayEdiCode);
+
+        assertThat(payRule.getCoverageRate()).isEqualTo(80);
+        assertThat(payRule.getDeductibleAmount()).isEqualTo(10000);
+        assertThat(payRule.getDisclaimer()).contains("3세대", "급여 기본계약", "비급여 특약");
+        assertThat(nonPayRule.getCoverageRate()).isEqualTo(70);
+        assertThat(nonPayRule.getDeductibleAmount()).isEqualTo(30000);
+        assertThat(nonPayRule.getDisclaimer()).contains("비급여", "특약 분리", "항목별 한도");
+    }
+
+    @Test
+    void 사세대는_비급여_이용량_기반_보험료_차등_대상임을_표시한다() {
+        EdiCode payEdiCode = createEdiCode("EDI010", "외래 진료", "일반", PayType.PAY, FeeType.MEDICAL);
+        EdiCode nonPayEdiCode = createEdiCode("EDI011", "비급여 주사 치료", "주사", PayType.NON_PAY, FeeType.MEDICAL);
+        CoverageRuleGenerationContext fourthGenerationContext =
+                new CoverageRuleGenerationContext(1L, InsuranceGeneration.FOURTH);
+
+        CoverageRule payRule = coverageRuleGenerator.generate(fourthGenerationContext, payEdiCode);
+        CoverageRule nonPayRule = coverageRuleGenerator.generate(fourthGenerationContext, nonPayEdiCode);
+
+        assertThat(payRule.getCoverageRate()).isEqualTo(80);
+        assertThat(payRule.getDeductibleAmount()).isEqualTo(10000);
+        assertThat(payRule.getDisclaimer()).contains("4세대", "급여 20%", "비급여 30%", "보험료 차등");
+        assertThat(nonPayRule.getCoverageRate()).isEqualTo(70);
+        assertThat(nonPayRule.getDeductibleAmount()).isEqualTo(30000);
+        assertThat(nonPayRule.getDisclaimer()).contains("비급여", "이용량 기반", "연간 비급여 사용량");
+    }
+
+    private EdiCode createEdiCode(
+            String code,
+            String treatmentName,
+            String feeDivisionNumber,
+            PayType payType,
+            FeeType feeType
+    ) {
+        return EdiCode.create(
+                code,
+                treatmentName,
+                feeDivisionNumber,
+                payType,
+                100000,
+                BigDecimal.valueOf(123.45),
+                LocalDate.of(2026, 1, 1),
+                feeType
+        );
+    }
+}

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleResolverTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleResolverTest.java
@@ -6,6 +6,7 @@ import com.silsonfit.silsonfit_api.domain.calculation.enums.PurposeType;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.VisitType;
 import com.silsonfit.silsonfit_api.domain.calculation.repository.CoverageRuleRepository;
+import com.silsonfit.silsonfit_api.domain.calculation.repository.EdiCodeRepository;
 import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleContext;
 import com.silsonfit.silsonfit_api.global.error.BusinessException;
 import com.silsonfit.silsonfit_api.global.error.ErrorCode;
@@ -28,6 +29,9 @@ class CoverageRuleResolverTest {
 
     @Autowired
     CoverageRuleRepository coverageRuleRepository;
+
+    @Autowired
+    EdiCodeRepository ediCodeRepository;
 
     @Test
     void EDI코드_기반_보장룰이_있으면_우선_반환한다() {
@@ -73,6 +77,9 @@ class CoverageRuleResolverTest {
         );
         coverageRuleRepository.save(treatmentInfoRule);
 
+        assertThat(ediCodeRepository.findByCode("MRI001")).isEmpty();
+        assertThat(coverageRuleRepository.findByInsuranceIdAndEdiCode(1L, "MRI001")).isEmpty();
+
         CoverageRule resolvedRule = coverageRuleResolver.resolve(
                 context,
                 "MRI001",
@@ -85,6 +92,7 @@ class CoverageRuleResolverTest {
         assertThat(resolvedRule.getTreatmentCategory()).isEqualTo(TreatmentCategory.MRI);
         assertThat(resolvedRule.getCoverageRate()).isEqualTo(70);
         assertThat(coverageRuleRepository.findByInsuranceIdAndEdiCode(1L, "MRI001")).isPresent();
+        assertThat(ediCodeRepository.findByCode("MRI001")).isPresent();
     }
 
     @Test

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleResolverTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleResolverTest.java
@@ -1,10 +1,12 @@
 package com.silsonfit.silsonfit_api.domain.calculation.service;
 
 import com.silsonfit.silsonfit_api.domain.calculation.entity.CoverageRule;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.InsuranceGeneration;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.PurposeType;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.VisitType;
 import com.silsonfit.silsonfit_api.domain.calculation.repository.CoverageRuleRepository;
+import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleContext;
 import com.silsonfit.silsonfit_api.global.error.BusinessException;
 import com.silsonfit.silsonfit_api.global.error.ErrorCode;
 import org.junit.jupiter.api.Test;
@@ -18,6 +20,8 @@ import static org.assertj.core.api.Assertions.assertThatThrownBy;
 @SpringBootTest
 @Transactional
 class CoverageRuleResolverTest {
+
+    CoverageRuleContext context = new CoverageRuleContext(1L, InsuranceGeneration.FOURTH);
 
     @Autowired
     CoverageRuleResolver coverageRuleResolver;
@@ -47,7 +51,7 @@ class CoverageRuleResolverTest {
         coverageRuleRepository.save(treatmentInfoRule);
 
         CoverageRule resolvedRule = coverageRuleResolver.resolve(
-                1L,
+                context,
                 "EDI001",
                 VisitType.OUTPATIENT,
                 TreatmentCategory.MRI,
@@ -58,7 +62,7 @@ class CoverageRuleResolverTest {
     }
 
     @Test
-    void EDI코드_기반_보장룰이_없으면_진료정보_기반_보장룰을_반환한다() {
+    void EDI코드_기반_보장룰이_없으면_EDI정보로_보장룰을_생성한다() {
         CoverageRule treatmentInfoRule = createCoverageRule(
                 1L,
                 null,
@@ -70,27 +74,30 @@ class CoverageRuleResolverTest {
         coverageRuleRepository.save(treatmentInfoRule);
 
         CoverageRule resolvedRule = coverageRuleResolver.resolve(
-                1L,
-                "UNKNOWN_EDI",
+                context,
+                "MRI001",
                 VisitType.OUTPATIENT,
                 TreatmentCategory.MRI,
                 PurposeType.TREATMENT
         );
 
-        assertThat(resolvedRule.getBasis()).isEqualTo("진료정보 룰");
+        assertThat(resolvedRule.getEdiCode()).isEqualTo("MRI001");
+        assertThat(resolvedRule.getTreatmentCategory()).isEqualTo(TreatmentCategory.MRI);
+        assertThat(resolvedRule.getCoverageRate()).isEqualTo(70);
+        assertThat(coverageRuleRepository.findByInsuranceIdAndEdiCode(1L, "MRI001")).isPresent();
     }
 
     @Test
-    void 조회되는_보장룰이_없으면_예외가_발생한다() {
+    void EDI코드가_있지만_EDI정보도_없으면_예외가_발생한다() {
         assertThatThrownBy(() -> coverageRuleResolver.resolve(
-                1L,
+                context,
                 "UNKNOWN_EDI",
                 VisitType.OUTPATIENT,
                 TreatmentCategory.MRI,
                 PurposeType.TREATMENT
         ))
                 .isInstanceOf(BusinessException.class)
-                .hasMessage(ErrorCode.COVERAGE_RULE_NOT_FOUND.getMessage());
+                .hasMessage(ErrorCode.EDI_CODE_NOT_FOUND.getMessage());
     }
 
     private CoverageRule createCoverageRule(


### PR DESCRIPTION
### 💻 작업 내용

* 보장 룰 자동 생성 정책 추가
* EDI Code 객체 미존재 시 fallback 처리 플로우 구현
* 테스트용 Fake Client 추가
* 보장 룰 생성 시 필요한 Context 전달 구조 정리
* EDI 룰 자동 생성 플로우 테스트 추가

### ✨ 리뷰 포인트

* EDI Code가 존재하지 않을 때 처리 흐름이 적절한지
* 보장 룰 생성 책임이 정책 객체로 잘 분리되었는지

### 📝 메모

* 외부 공공 EDI Client 연동은 이후 PR에서 별도로 진행할 예정입니다.
* 현재는 기간 내 개발이 더 중요한 것 같아 세대별 규칙이 정확하지 않습니다. 추후 고도화 과정에서 세대별 규칙을 좀 더 구체화하겠습니다.

### 🎯 관련 이슈

closed #30