### PR TITLE
feat: Insurance 엔티티 및 세대 판별 API 구현

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/controller/InsuranceController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/controller/InsuranceController.java
@@ -1,0 +1,34 @@
+package com.silsonfit.silsonfit_api.domain.insurance.controller;
+
+import com.silsonfit.silsonfit_api.domain.insurance.dto.GenerationRequest;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.GenerationResponse;
+import com.silsonfit.silsonfit_api.domain.insurance.service.InsuranceService;
+import com.silsonfit.silsonfit_api.global.common.ApiResponse;
+import jakarta.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 보험 관련 API
+ *
+ * 세대 판별 API 제공
+ */
+@RestController
+@RequestMapping("/api/insurance")
+@RequiredArgsConstructor
+public class InsuranceController {
+
+    private final InsuranceService insuranceService;
+
+    /**
+     * 가입 연월 기반 세대 판별
+     */
+    @PostMapping("/generation")
+    public ApiResponse<GenerationResponse> determineGeneration(
+            @Valid @RequestBody GenerationRequest request) {
+        return ApiResponse.success(insuranceService.determineGeneration(request));
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/GenerationRequest.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/GenerationRequest.java
@@ -1,0 +1,14 @@
+package com.silsonfit.silsonfit_api.domain.insurance.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * 세대 판별 요청 DTO
+ */
+public record GenerationRequest(
+        @NotBlank(message = "가입 연월은 필수입니다.")
+        @Pattern(regexp = "^\\d{4}-(0[1-9]|1[0-2])$", message = "가입 연월 형식은 YYYY-MM이어야 합니다.")
+        String subscribedYearMonth
+) {
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/GenerationResponse.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/GenerationResponse.java
@@ -4,7 +4,6 @@ package com.silsonfit.silsonfit_api.domain.insurance.dto;
  * 세대 판별 응답 DTO
  */
 public record GenerationResponse(
-        int generation,
-        String description
+        int generation
 ) {
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/GenerationResponse.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/GenerationResponse.java
@@ -1,0 +1,10 @@
+package com.silsonfit.silsonfit_api.domain.insurance.dto;
+
+/**
+ * 세대 판별 응답 DTO
+ */
+public record GenerationResponse(
+        int generation,
+        String description
+) {
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/InsuranceInfoDto.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/InsuranceInfoDto.java
@@ -1,0 +1,25 @@
+package com.silsonfit.silsonfit_api.domain.insurance.dto;
+
+import com.silsonfit.silsonfit_api.domain.insurance.enums.CautionPoint;
+import com.silsonfit.silsonfit_api.domain.insurance.enums.ContractType;
+import com.silsonfit.silsonfit_api.domain.insurance.enums.CoverageStructure;
+
+/**
+ * 타 도메인(계산/분석)에 보험 정보를 제공하는 DTO
+ *
+ * Insurance(보험 상품) + UserInsurance(사용자 등록 정보)를 함께 제공
+ */
+public record InsuranceInfoDto(
+        Long insuranceId,
+        String companyName,
+        String productName,
+        ContractType contractType,
+        int generation,
+        CoverageStructure coverageStructure,
+        CautionPoint cautionPoint,
+        String pdfFileUrl,
+        String pdfFileName,
+        String subscribedAt,
+        boolean hasNonCoveredRider
+) {
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/entity/Insurance.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/entity/Insurance.java
@@ -1,0 +1,75 @@
+package com.silsonfit.silsonfit_api.domain.insurance.entity;
+
+import com.silsonfit.silsonfit_api.domain.insurance.enums.CautionPoint;
+import com.silsonfit.silsonfit_api.domain.insurance.enums.ContractType;
+import com.silsonfit.silsonfit_api.domain.insurance.enums.CoverageStructure;
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 보험 상품 마스터 엔티티
+ *
+ * 빅5 손보사 인기 상품 정보를 관리한다.
+ */
+@Entity
+@Table(name = "insurances")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class Insurance {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 보험사명 (삼성화재, 현대해상, DB손해보험, KB손해보험, 메리츠화재)
+    @Column(nullable = false)
+    private String companyName;
+
+    // 보험 상품명
+    @Column(nullable = false)
+    private String productName;
+
+    // 계약 유형
+    @Enumerated(EnumType.STRING)
+    @Column
+    private ContractType contractType;
+
+    // 세대 (1~4)
+    @Column(nullable = false)
+    private int generation;
+
+    // 보장 구조
+    @Enumerated(EnumType.STRING)
+    @Column
+    private CoverageStructure coverageStructure;
+
+    // 주의 사항
+    @Enumerated(EnumType.STRING)
+    @Column
+    private CautionPoint cautionPoint;
+
+    // 약관 PDF S3 경로
+    @Column
+    private String pdfFileUrl;
+
+    // 약관 PDF 원본 파일명
+    @Column
+    private String pdfFileName;
+
+    @Builder
+    public Insurance(String companyName, String productName, ContractType contractType,
+                     int generation, CoverageStructure coverageStructure, CautionPoint cautionPoint,
+                     String pdfFileUrl, String pdfFileName) {
+        this.companyName = companyName;
+        this.productName = productName;
+        this.contractType = contractType;
+        this.generation = generation;
+        this.coverageStructure = coverageStructure;
+        this.cautionPoint = cautionPoint;
+        this.pdfFileUrl = pdfFileUrl;
+        this.pdfFileName = pdfFileName;
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/entity/UserInsurance.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/entity/UserInsurance.java
@@ -1,0 +1,48 @@
+package com.silsonfit.silsonfit_api.domain.insurance.entity;
+
+import jakarta.persistence.*;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+/**
+ * 사용자 보험 등록 엔티티
+ *
+ * 사용자가 등록한 보험 정보를 관리한다. (최대 5개)
+ */
+@Entity
+@Table(name = "user_insurances")
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class UserInsurance {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    // 사용자 ID (User 도메인 → ID 참조)
+    @Column(name = "user_id", nullable = false)
+    private Long userId;
+
+    // 보험 상품 (Insurance 도메인 → 객체 참조)
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "insurance_id", nullable = false)
+    private Insurance insurance;
+
+    // 가입 연월 (예: "2020-03")
+    @Column(nullable = false)
+    private String subscribedAt;
+
+    // 비급여 특약 가입 여부 (4세대)
+    @Column(nullable = false)
+    private boolean hasNonCoveredRider;
+
+    @Builder
+    public UserInsurance(Long userId, Insurance insurance, String subscribedAt, boolean hasNonCoveredRider) {
+        this.userId = userId;
+        this.insurance = insurance;
+        this.subscribedAt = subscribedAt;
+        this.hasNonCoveredRider = hasNonCoveredRider;
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/enums/CautionPoint.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/enums/CautionPoint.java
@@ -1,0 +1,23 @@
+package com.silsonfit.silsonfit_api.domain.insurance.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 주의 포인트
+ */
+@Getter
+@AllArgsConstructor
+public enum CautionPoint {
+
+    HIGH_DEDUCTIBLE("자기부담높음"),
+    RENEWAL_TYPE("갱신형"),
+    RE_ENROLLMENT("재가입형"),
+    LIMITED_COVERAGE("보장제한많음"),
+    CLAIM_CAUTION("청구유의"),
+    DISCLAIMER_CHECK("면책확인"),
+    THREE_UNCOVERED_CAUTION("3대비급여주의"),
+    PREMIUM_ROOM_CAUTION("상급병실주의");
+
+    private final String displayName;
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/enums/ContractType.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/enums/ContractType.java
@@ -1,0 +1,21 @@
+package com.silsonfit.silsonfit_api.domain.insurance.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 계약 유형
+ */
+@Getter
+@AllArgsConstructor
+public enum ContractType {
+
+    INDIVIDUAL("개인실손"),
+    GROUP("단체실손"),
+    CONVERSION("전환용"),
+    RENEWAL("재개용"),
+    SENIOR("노후실손"),
+    PRE_EXISTING("유병력자");
+
+    private final String displayName;
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/enums/CoverageStructure.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/enums/CoverageStructure.java
@@ -1,0 +1,24 @@
+package com.silsonfit.silsonfit_api.domain.insurance.enums;
+
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 보장 구조
+ */
+@Getter
+@AllArgsConstructor
+public enum CoverageStructure {
+
+    COVERED_FOCUSED("급여중심"),
+    COVERED_AND_UNCOVERED("급여+비급여"),
+    THREE_UNCOVERED("3대비급여"),
+    UNCOVERED_INCLUDED("비급여포함"),
+    RIDER_INCLUDED("특약포함"),
+    INPATIENT_OUTPATIENT("입·통원포함"),
+    OUTPATIENT_FOCUSED("통원중심"),
+    BASIC_FOCUSED("기본형중심"),
+    PRESCRIPTION_INCLUDED("처방조제포함");
+
+    private final String displayName;
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/enums/InsuranceGeneration.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/enums/InsuranceGeneration.java
@@ -1,0 +1,59 @@
+package com.silsonfit.silsonfit_api.domain.insurance.enums;
+
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+import java.time.YearMonth;
+
+/**
+ * 보험 세대 판별 enum
+ *
+ * 가입 연월 기준으로 1~4세대를 판별한다.
+ * 별도 테이블 없이 도메인 내부에서 처리.
+ */
+@Getter
+@AllArgsConstructor
+public enum InsuranceGeneration {
+
+    FIRST(1, null, YearMonth.of(2009, 7),
+            "1세대: 2009년 7월 이전 가입"),
+    SECOND(2, YearMonth.of(2009, 8), YearMonth.of(2017, 3),
+            "2세대: 2009년 8월 ~ 2017년 3월 가입"),
+    THIRD(3, YearMonth.of(2017, 4), YearMonth.of(2021, 6),
+            "3세대: 2017년 4월 ~ 2021년 6월 가입"),
+    FOURTH(4, YearMonth.of(2021, 7), null,
+            "4세대: 2021년 7월 이후 가입");
+
+    private final int generation;
+    private final YearMonth startMonth;
+    private final YearMonth endMonth;
+    private final String description;
+
+    /**
+     * 가입 연월로 세대 판별
+     *
+     * @param subscribedYearMonth 가입 연월 (예: "2020-03")
+     * @return 해당 세대 enum
+     */
+    public static InsuranceGeneration from(String subscribedYearMonth) {
+        YearMonth target;
+        try {
+            target = YearMonth.parse(subscribedYearMonth);
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.INVALID_SUBSCRIBED_DATE);
+        }
+
+        for (InsuranceGeneration gen : values()) {
+            boolean afterStart = (gen.startMonth == null) || !target.isBefore(gen.startMonth);
+            boolean beforeEnd = (gen.endMonth == null) || !target.isAfter(gen.endMonth);
+
+            if (afterStart && beforeEnd) {
+                return gen;
+            }
+        }
+
+        throw new BusinessException(ErrorCode.INVALID_SUBSCRIBED_DATE);
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/repository/InsuranceRepository.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/repository/InsuranceRepository.java
@@ -1,0 +1,10 @@
+package com.silsonfit.silsonfit_api.domain.insurance.repository;
+
+import com.silsonfit.silsonfit_api.domain.insurance.entity.Insurance;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+/**
+ * 보험 상품 Repository
+ */
+public interface InsuranceRepository extends JpaRepository<Insurance, Long> {
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/repository/UserInsuranceRepository.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/repository/UserInsuranceRepository.java
@@ -1,0 +1,25 @@
+package com.silsonfit.silsonfit_api.domain.insurance.repository;
+
+import com.silsonfit.silsonfit_api.domain.insurance.entity.UserInsurance;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.jpa.repository.Query;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
+
+/**
+ * 사용자 보험 등록 Repository
+ */
+public interface UserInsuranceRepository extends JpaRepository<UserInsurance, Long> {
+
+    /**
+     * 사용자의 등록 보험 목록 조회 (Insurance 함께 로딩)
+     */
+    @Query("SELECT ui FROM UserInsurance ui JOIN FETCH ui.insurance WHERE ui.userId = :userId")
+    List<UserInsurance> findByUserIdWithInsurance(@Param("userId") Long userId);
+
+    /**
+     * 사용자의 등록 보험 개수 조회
+     */
+    long countByUserId(Long userId);
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
@@ -1,0 +1,81 @@
+package com.silsonfit.silsonfit_api.domain.insurance.service;
+
+import com.silsonfit.silsonfit_api.domain.insurance.dto.GenerationRequest;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.GenerationResponse;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceInfoDto;
+import com.silsonfit.silsonfit_api.domain.insurance.entity.Insurance;
+import com.silsonfit.silsonfit_api.domain.insurance.enums.InsuranceGeneration;
+import com.silsonfit.silsonfit_api.domain.insurance.entity.UserInsurance;
+import com.silsonfit.silsonfit_api.domain.insurance.repository.InsuranceRepository;
+import com.silsonfit.silsonfit_api.domain.insurance.repository.UserInsuranceRepository;
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 보험 관련 비즈니스 로직
+ *
+ * 세대 판별, 타 도메인 보험 정보 제공
+ */
+@Service
+@RequiredArgsConstructor
+public class InsuranceService {
+
+    private final InsuranceRepository insuranceRepository;
+    private final UserInsuranceRepository userInsuranceRepository;
+
+    /**
+     * 가입 연월 기반 세대 판별
+     *
+     * @param request 가입 연월
+     * @return 세대 번호 및 설명
+     */
+    public GenerationResponse determineGeneration(GenerationRequest request) {
+        InsuranceGeneration gen = InsuranceGeneration.from(request.subscribedYearMonth());
+        return new GenerationResponse(gen.getGeneration(), gen.getDescription());
+    }
+
+    /**
+     * 타 도메인(계산/분석)에서 사용할 보험 정보 조회
+     *
+     * @param userInsuranceId 사용자 보험 등록 ID
+     * @return 보험 상품 정보 DTO
+     */
+    @Transactional(readOnly = true)
+    public InsuranceInfoDto getInsuranceInfo(Long userInsuranceId) {
+        UserInsurance userInsurance = userInsuranceRepository.findById(userInsuranceId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_INSURANCE_NOT_FOUND));
+
+        Insurance insurance = userInsurance.getInsurance();
+
+        return new InsuranceInfoDto(
+                insurance.getId(),
+                insurance.getCompanyName(),
+                insurance.getProductName(),
+                insurance.getContractType(),
+                insurance.getGeneration(),
+                insurance.getCoverageStructure(),
+                insurance.getCautionPoint(),
+                insurance.getPdfFileUrl(),
+                insurance.getPdfFileName(),
+                userInsurance.getSubscribedAt(),
+                userInsurance.isHasNonCoveredRider()
+        );
+    }
+
+    /**
+     * 보험 ID로 세대 정보 조회
+     *
+     * @param insuranceId 보험 상품 ID
+     * @return 세대 번호
+     */
+    @Transactional(readOnly = true)
+    public int getGenerationByInsuranceId(Long insuranceId) {
+        Insurance insurance = insuranceRepository.findById(insuranceId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.INSURANCE_NOT_FOUND));
+
+        return insurance.getGeneration();
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
@@ -34,7 +34,7 @@ public class InsuranceService {
      */
     public GenerationResponse determineGeneration(GenerationRequest request) {
         InsuranceGeneration gen = InsuranceGeneration.from(request.subscribedYearMonth());
-        return new GenerationResponse(gen.getGeneration(), gen.getDescription());
+        return new GenerationResponse(gen.getGeneration());
     }
 
     /**

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
@@ -36,6 +36,9 @@ public enum ErrorCode {
     HISTORY_ACCESS_DENIED(403, "해당 분석 이력에 대한 접근 권한이 없습니다."),
 
     // ── Insurance ──
+    INSURANCE_NOT_FOUND(404, "보험 상품을 찾을 수 없습니다."),
+    USER_INSURANCE_NOT_FOUND(404, "등록된 보험을 찾을 수 없습니다."),
+    INVALID_SUBSCRIBED_DATE(400, "세대를 판별할 수 없는 가입 연월입니다."),
 
     // ── Calculator ──
 

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/insurance/enums/InsuranceGenerationTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/insurance/enums/InsuranceGenerationTest.java
@@ -1,0 +1,54 @@
+package com.silsonfit.silsonfit_api.domain.insurance.enums;
+
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+/**
+ * 세대 판별 enum 단위 테스트
+ */
+class InsuranceGenerationTest {
+
+    @Test
+    @DisplayName("2009년 7월 이전 가입 → 1세대")
+    void firstGeneration() {
+        assertThat(InsuranceGeneration.from("2005-03").getGeneration()).isEqualTo(1);
+        assertThat(InsuranceGeneration.from("2009-07").getGeneration()).isEqualTo(1);
+    }
+
+    @Test
+    @DisplayName("2009년 8월 ~ 2017년 3월 가입 → 2세대")
+    void secondGeneration() {
+        assertThat(InsuranceGeneration.from("2009-08").getGeneration()).isEqualTo(2);
+        assertThat(InsuranceGeneration.from("2015-06").getGeneration()).isEqualTo(2);
+        assertThat(InsuranceGeneration.from("2017-03").getGeneration()).isEqualTo(2);
+    }
+
+    @Test
+    @DisplayName("2017년 4월 ~ 2021년 6월 가입 → 3세대")
+    void thirdGeneration() {
+        assertThat(InsuranceGeneration.from("2017-04").getGeneration()).isEqualTo(3);
+        assertThat(InsuranceGeneration.from("2020-03").getGeneration()).isEqualTo(3);
+        assertThat(InsuranceGeneration.from("2021-06").getGeneration()).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("2021년 7월 이후 가입 → 4세대")
+    void fourthGeneration() {
+        assertThat(InsuranceGeneration.from("2021-07").getGeneration()).isEqualTo(4);
+        assertThat(InsuranceGeneration.from("2024-01").getGeneration()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("잘못된 형식의 가입 연월이면 INVALID_SUBSCRIBED_DATE 예외 발생")
+    void invalidFormat() {
+        assertThatThrownBy(() -> InsuranceGeneration.from("2020"))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INVALID_SUBSCRIBED_DATE);
+    }
+}

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceServiceTest.java
@@ -1,0 +1,164 @@
+package com.silsonfit.silsonfit_api.domain.insurance.service;
+
+import com.silsonfit.silsonfit_api.domain.insurance.dto.GenerationRequest;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.GenerationResponse;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceInfoDto;
+import com.silsonfit.silsonfit_api.domain.insurance.enums.CautionPoint;
+import com.silsonfit.silsonfit_api.domain.insurance.enums.ContractType;
+import com.silsonfit.silsonfit_api.domain.insurance.enums.CoverageStructure;
+import com.silsonfit.silsonfit_api.domain.insurance.entity.Insurance;
+import com.silsonfit.silsonfit_api.domain.insurance.entity.UserInsurance;
+import com.silsonfit.silsonfit_api.domain.insurance.repository.InsuranceRepository;
+import com.silsonfit.silsonfit_api.domain.insurance.repository.UserInsuranceRepository;
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+/**
+ * InsuranceService 단위 테스트
+ *
+ * 세대 판별 및 보험 정보 조회 로직 검증
+ */
+@ExtendWith(MockitoExtension.class)
+class InsuranceServiceTest {
+
+    @Mock
+    private InsuranceRepository insuranceRepository;
+
+    @Mock
+    private UserInsuranceRepository userInsuranceRepository;
+
+    @InjectMocks
+    private InsuranceService insuranceService;
+
+    // ──────────── determineGeneration ────────────
+
+    @Test
+    @DisplayName("가입 연월 2020-03 → 3세대 판별")
+    void determineGeneration_thirdGen() {
+        // when
+        GenerationResponse response = insuranceService.determineGeneration(
+                new GenerationRequest("2020-03"));
+
+        // then
+        assertThat(response.generation()).isEqualTo(3);
+        assertThat(response.description()).contains("3세대");
+    }
+
+    @Test
+    @DisplayName("가입 연월 2023-01 → 4세대 판별")
+    void determineGeneration_fourthGen() {
+        // when
+        GenerationResponse response = insuranceService.determineGeneration(
+                new GenerationRequest("2023-01"));
+
+        // then
+        assertThat(response.generation()).isEqualTo(4);
+    }
+
+    // ──────────── getInsuranceInfo ────────────
+
+    @Test
+    @DisplayName("보험 정보 조회 성공")
+    void getInsuranceInfo_success() {
+        // given
+        Insurance insurance = Insurance.builder()
+                .companyName("삼성화재")
+                .productName("삼성화재 실손의료비보험")
+                .contractType(ContractType.INDIVIDUAL)
+                .generation(3)
+                .coverageStructure(CoverageStructure.COVERED_AND_UNCOVERED)
+                .cautionPoint(CautionPoint.RENEWAL_TYPE)
+                .pdfFileUrl("https://s3.../samsung.pdf")
+                .pdfFileName("삼성화재_약관.pdf")
+                .build();
+        ReflectionTestUtils.setField(insurance, "id", 1L);
+
+        UserInsurance userInsurance = UserInsurance.builder()
+                .userId(1L)
+                .insurance(insurance)
+                .subscribedAt("2020-03")
+                .hasNonCoveredRider(false)
+                .build();
+        ReflectionTestUtils.setField(userInsurance, "id", 10L);
+
+        given(userInsuranceRepository.findById(10L)).willReturn(Optional.of(userInsurance));
+
+        // when
+        InsuranceInfoDto result = insuranceService.getInsuranceInfo(10L);
+
+        // then
+        assertThat(result.companyName()).isEqualTo("삼성화재");
+        assertThat(result.productName()).isEqualTo("삼성화재 실손의료비보험");
+        assertThat(result.contractType()).isEqualTo(ContractType.INDIVIDUAL);
+        assertThat(result.generation()).isEqualTo(3);
+        assertThat(result.coverageStructure()).isEqualTo(CoverageStructure.COVERED_AND_UNCOVERED);
+        assertThat(result.cautionPoint()).isEqualTo(CautionPoint.RENEWAL_TYPE);
+        assertThat(result.pdfFileUrl()).isEqualTo("https://s3.../samsung.pdf");
+        assertThat(result.subscribedAt()).isEqualTo("2020-03");
+        assertThat(result.hasNonCoveredRider()).isFalse();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 사용자 보험 조회 시 USER_INSURANCE_NOT_FOUND 예외")
+    void getInsuranceInfo_notFound() {
+        // given
+        given(userInsuranceRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> insuranceService.getInsuranceInfo(999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_INSURANCE_NOT_FOUND);
+    }
+
+    // ──────────── getGenerationByInsuranceId ────────────
+
+    @Test
+    @DisplayName("보험 ID로 세대 조회 성공")
+    void getGenerationByInsuranceId_success() {
+        // given
+        Insurance insurance = Insurance.builder()
+                .companyName("삼성화재")
+                .productName("삼성화재 실손의료비보험")
+                .contractType(ContractType.INDIVIDUAL)
+                .generation(3)
+                .coverageStructure(CoverageStructure.COVERED_AND_UNCOVERED)
+                .cautionPoint(CautionPoint.RENEWAL_TYPE)
+                .build();
+        ReflectionTestUtils.setField(insurance, "id", 1L);
+
+        given(insuranceRepository.findById(1L)).willReturn(Optional.of(insurance));
+
+        // when
+        int generation = insuranceService.getGenerationByInsuranceId(1L);
+
+        // then
+        assertThat(generation).isEqualTo(3);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 보험 ID로 세대 조회 시 INSURANCE_NOT_FOUND 예외")
+    void getGenerationByInsuranceId_notFound() {
+        // given
+        given(insuranceRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> insuranceService.getGenerationByInsuranceId(999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INSURANCE_NOT_FOUND);
+    }
+}

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceServiceTest.java
@@ -54,7 +54,6 @@ class InsuranceServiceTest {
 
         // then
         assertThat(response.generation()).isEqualTo(3);
-        assertThat(response.description()).contains("3세대");
     }
 
     @Test


### PR DESCRIPTION
<!-- PR의 타입은 Label을 통해 나타내주세요. -->

### 💻 작업 내용
<!-- 진행한 작업 내용에 대해 작성해주세요. -->
- 보험 도메인 엔티티 구현 (Insurance, UserInsurance)
- 보험 관련 enum 정의 (InsuranceGeneration, ContractType, CoverageStructure, CautionPoint)
- 가입 연월 기반 세대 판별 API
- 타 도메인(계산/분석)을 위한 보험 정보 조회 메서드 (getInsuranceInfo, getGenerationByInsuranceId)
- Insurance 에러코드 3개 추가
- 세대 판별 enum 테스트 + 서비스 단위 테스트

### ✨ 리뷰 포인트
<!-- (ex) query 가 너무 복잡한 것 같은데 이 위주로 봐주세요. -->
- UserInsurance  → Insurance를 객체 참조로 구현했습니다. 조회 시 Insurance 정보가 항상 함께 필요하여 fetch join으로 한 번에 조회하기 위함입니다.
- 세대 판별 로직을 별도 테이블 없이 InsuranceGeneration enum 내부에서 기간 비교로 처리했습니다.

### 📝 메모
<!-- PR 관련 전달사항이 있다면 이곳에 작성해주세요. -->
- 타 도메인을 위한 메서드 만들어 두었습니다. 혹시 또 필요한 거 있으면 바로 반영하도록 하겠습니다!

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
closed #35 
