### PR TITLE
feat: 보험 등록/삭제/조회 및 상품 목록 API 구현

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/controller/InsuranceController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/controller/InsuranceController.java
@@ -5,6 +5,7 @@ import com.silsonfit.silsonfit_api.domain.insurance.dto.GenerationResponse;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceProductResponse;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceRegisterRequest;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceRegisterResponse;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.UserInsuranceResponse;
 import com.silsonfit.silsonfit_api.domain.insurance.service.InsuranceService;
 import com.silsonfit.silsonfit_api.global.auth.CustomUserDetails;
 import com.silsonfit.silsonfit_api.global.common.ApiResponse;
@@ -18,7 +19,7 @@ import java.util.List;
 /**
  * 보험 관련 API
  *
- * 세대 판별, 보험 등록/삭제, 상품 목록 조회 제공
+ * 세대 판별, 보험 등록/삭제, 내 보험 목록, 상품 목록 조회 제공
  */
 @RestController
 @RequestMapping("/api/insurance")
@@ -55,6 +56,15 @@ public class InsuranceController {
             @PathVariable("id") Long userInsuranceId) {
         insuranceService.delete(userDetails.getUserId(), userInsuranceId);
         return ApiResponse.success();
+    }
+
+    /**
+     * 내 보험 목록 조회
+     */
+    @GetMapping("/list")
+    public ApiResponse<List<UserInsuranceResponse>> getMyInsurances(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        return ApiResponse.success(insuranceService.getMyInsurances(userDetails.getUserId()));
     }
 
     /**

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/controller/InsuranceController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/controller/InsuranceController.java
@@ -2,6 +2,7 @@ package com.silsonfit.silsonfit_api.domain.insurance.controller;
 
 import com.silsonfit.silsonfit_api.domain.insurance.dto.GenerationRequest;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.GenerationResponse;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceCompanyResponse;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceProductResponse;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceRegisterRequest;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceRegisterResponse;
@@ -19,7 +20,7 @@ import java.util.List;
 /**
  * 보험 관련 API
  *
- * 세대 판별, 보험 등록/삭제, 내 보험 목록, 상품 목록 조회 제공
+ * 세대 판별, 보험사 목록, 보험 등록/삭제, 내 보험 목록, 상품 목록 조회 제공
  */
 @RestController
 @RequestMapping("/api/insurance")
@@ -27,6 +28,14 @@ import java.util.List;
 public class InsuranceController {
 
     private final InsuranceService insuranceService;
+
+    /**
+     * 보험사 목록 조회
+     */
+    @GetMapping("/companies")
+    public ApiResponse<List<InsuranceCompanyResponse>> getCompanies() {
+        return ApiResponse.success(insuranceService.getCompanies());
+    }
 
     /**
      * 가입 연월 기반 세대 판별

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/controller/InsuranceController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/controller/InsuranceController.java
@@ -15,7 +15,7 @@ import org.springframework.web.bind.annotation.*;
 /**
  * 보험 관련 API
  *
- * 세대 판별, 보험 등록 제공
+ * 세대 판별, 보험 등록/삭제 제공
  */
 @RestController
 @RequestMapping("/api/insurance")
@@ -41,5 +41,16 @@ public class InsuranceController {
             @AuthenticationPrincipal CustomUserDetails userDetails,
             @Valid @RequestBody InsuranceRegisterRequest request) {
         return ApiResponse.success(insuranceService.register(userDetails.getUserId(), request));
+    }
+
+    /**
+     * 보험 삭제
+     */
+    @DeleteMapping("/{id}")
+    public ApiResponse<Void> delete(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable("id") Long userInsuranceId) {
+        insuranceService.delete(userDetails.getUserId(), userInsuranceId);
+        return ApiResponse.success();
     }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/controller/InsuranceController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/controller/InsuranceController.java
@@ -2,6 +2,7 @@ package com.silsonfit.silsonfit_api.domain.insurance.controller;
 
 import com.silsonfit.silsonfit_api.domain.insurance.dto.GenerationRequest;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.GenerationResponse;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceProductResponse;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceRegisterRequest;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceRegisterResponse;
 import com.silsonfit.silsonfit_api.domain.insurance.service.InsuranceService;
@@ -12,10 +13,12 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
 import org.springframework.web.bind.annotation.*;
 
+import java.util.List;
+
 /**
  * 보험 관련 API
  *
- * 세대 판별, 보험 등록/삭제 제공
+ * 세대 판별, 보험 등록/삭제, 상품 목록 조회 제공
  */
 @RestController
 @RequestMapping("/api/insurance")
@@ -52,5 +55,15 @@ public class InsuranceController {
             @PathVariable("id") Long userInsuranceId) {
         insuranceService.delete(userDetails.getUserId(), userInsuranceId);
         return ApiResponse.success();
+    }
+
+    /**
+     * 보험사별 상품 목록 조회
+     */
+    @GetMapping("/products")
+    public ApiResponse<List<InsuranceProductResponse>> getProducts(
+            @RequestParam String companyName,
+            @RequestParam int generation) {
+        return ApiResponse.success(insuranceService.getProducts(companyName, generation));
     }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/controller/InsuranceController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/controller/InsuranceController.java
@@ -20,7 +20,7 @@ import java.util.List;
 /**
  * 보험 관련 API
  *
- * 세대 판별, 보험사 목록, 보험 등록/삭제, 내 보험 목록, 상품 목록 조회 제공
+ * 세대 판별, 보험사 목록, 보험 등록, 내 보험 목록, 상품 목록 조회 제공
  */
 @RestController
 @RequestMapping("/api/insurance")
@@ -56,9 +56,8 @@ public class InsuranceController {
         return ApiResponse.success(insuranceService.register(userDetails.getUserId(), request));
     }
 
-    /**
-     * 보험 삭제
-     */
+    // NOTE: 기능 명세에 보험 삭제 기능이 없어 주석 처리. 추후 필요 시 해제.
+    /*
     @DeleteMapping("/{id}")
     public ApiResponse<Void> delete(
             @AuthenticationPrincipal CustomUserDetails userDetails,
@@ -66,6 +65,7 @@ public class InsuranceController {
         insuranceService.delete(userDetails.getUserId(), userInsuranceId);
         return ApiResponse.success();
     }
+    */
 
     /**
      * 내 보험 목록 조회

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/controller/InsuranceController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/controller/InsuranceController.java
@@ -2,19 +2,20 @@ package com.silsonfit.silsonfit_api.domain.insurance.controller;
 
 import com.silsonfit.silsonfit_api.domain.insurance.dto.GenerationRequest;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.GenerationResponse;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceRegisterRequest;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceRegisterResponse;
 import com.silsonfit.silsonfit_api.domain.insurance.service.InsuranceService;
+import com.silsonfit.silsonfit_api.global.auth.CustomUserDetails;
 import com.silsonfit.silsonfit_api.global.common.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
-import org.springframework.web.bind.annotation.PostMapping;
-import org.springframework.web.bind.annotation.RequestBody;
-import org.springframework.web.bind.annotation.RequestMapping;
-import org.springframework.web.bind.annotation.RestController;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
 
 /**
  * 보험 관련 API
  *
- * 세대 판별 API 제공
+ * 세대 판별, 보험 등록 제공
  */
 @RestController
 @RequestMapping("/api/insurance")
@@ -30,5 +31,15 @@ public class InsuranceController {
     public ApiResponse<GenerationResponse> determineGeneration(
             @Valid @RequestBody GenerationRequest request) {
         return ApiResponse.success(insuranceService.determineGeneration(request));
+    }
+
+    /**
+     * 보험 등록
+     */
+    @PostMapping("/register")
+    public ApiResponse<InsuranceRegisterResponse> register(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @Valid @RequestBody InsuranceRegisterRequest request) {
+        return ApiResponse.success(insuranceService.register(userDetails.getUserId(), request));
     }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/controller/InsuranceController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/controller/InsuranceController.java
@@ -81,8 +81,8 @@ public class InsuranceController {
      */
     @GetMapping("/products")
     public ApiResponse<List<InsuranceProductResponse>> getProducts(
-            @RequestParam String companyName,
+            @RequestParam String companyId,
             @RequestParam int generation) {
-        return ApiResponse.success(insuranceService.getProducts(companyName, generation));
+        return ApiResponse.success(insuranceService.getProducts(companyId, generation));
     }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/GenerationRequest.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/GenerationRequest.java
@@ -7,8 +7,11 @@ import jakarta.validation.constraints.Pattern;
  * 세대 판별 요청 DTO
  */
 public record GenerationRequest(
+        @NotBlank(message = "보험사 ID는 필수입니다.")
+        String companyId,
+
         @NotBlank(message = "가입 연월은 필수입니다.")
         @Pattern(regexp = "^\\d{4}-(0[1-9]|1[0-2])$", message = "가입 연월 형식은 YYYY-MM이어야 합니다.")
-        String subscribedYearMonth
+        String joinDate
 ) {
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/InsuranceCompanyResponse.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/InsuranceCompanyResponse.java
@@ -1,0 +1,10 @@
+package com.silsonfit.silsonfit_api.domain.insurance.dto;
+
+/**
+ * 보험사 목록 응답 DTO
+ */
+public record InsuranceCompanyResponse(
+        String id,
+        String name
+) {
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/InsuranceProductResponse.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/InsuranceProductResponse.java
@@ -1,0 +1,10 @@
+package com.silsonfit.silsonfit_api.domain.insurance.dto;
+
+/**
+ * 보험 상품 목록 응답 DTO
+ */
+public record InsuranceProductResponse(
+        Long id,
+        String productName
+) {
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/InsuranceRegisterRequest.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/InsuranceRegisterRequest.java
@@ -1,0 +1,18 @@
+package com.silsonfit.silsonfit_api.domain.insurance.dto;
+
+import jakarta.validation.constraints.NotBlank;
+import jakarta.validation.constraints.NotNull;
+import jakarta.validation.constraints.Pattern;
+
+/**
+ * 보험 등록 요청 DTO
+ */
+public record InsuranceRegisterRequest(
+        @NotNull(message = "보험 상품 ID는 필수입니다.")
+        Long insuranceId,
+
+        @NotBlank(message = "가입 연월은 필수입니다.")
+        @Pattern(regexp = "^\\d{4}-(0[1-9]|1[0-2])$", message = "가입 연월 형식은 YYYY-MM이어야 합니다.")
+        String subscribedAt
+) {
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/InsuranceRegisterResponse.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/InsuranceRegisterResponse.java
@@ -1,0 +1,9 @@
+package com.silsonfit.silsonfit_api.domain.insurance.dto;
+
+/**
+ * 보험 등록 응답 DTO
+ */
+public record InsuranceRegisterResponse(
+        Long userInsuranceId
+) {
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/UserInsuranceResponse.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/UserInsuranceResponse.java
@@ -2,9 +2,15 @@ package com.silsonfit.silsonfit_api.domain.insurance.dto;
 
 /**
  * 사용자 등록 보험 목록 응답 DTO
+ *
+ * @param userInsuranceId 보험 등록 건의 고유 번호
+ * @param companyName 보험사명
+ * @param productName 보험 상품명
+ * @param generation 보험 세대
+ * @param joinDate 가입 연월
  */
 public record UserInsuranceResponse(
-        Long id,
+        Long userInsuranceId,
         String companyName,
         String productName,
         int generation,

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/UserInsuranceResponse.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/dto/UserInsuranceResponse.java
@@ -1,0 +1,13 @@
+package com.silsonfit.silsonfit_api.domain.insurance.dto;
+
+/**
+ * 사용자 등록 보험 목록 응답 DTO
+ */
+public record UserInsuranceResponse(
+        Long id,
+        String companyName,
+        String productName,
+        int generation,
+        String joinDate
+) {
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/entity/UserInsurance.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/entity/UserInsurance.java
@@ -45,4 +45,14 @@ public class UserInsurance {
         this.subscribedAt = subscribedAt;
         this.hasNonCoveredRider = hasNonCoveredRider;
     }
+
+    /**
+     * 소유권 확인
+     *
+     * @param userId 확인할 사용자 ID
+     * @return 본인 보험 여부
+     */
+    public boolean isOwnedBy(Long userId) {
+        return this.userId.equals(userId);
+    }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/enums/InsuranceCompany.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/enums/InsuranceCompany.java
@@ -1,0 +1,48 @@
+package com.silsonfit.silsonfit_api.domain.insurance.enums;
+
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import lombok.AllArgsConstructor;
+import lombok.Getter;
+
+/**
+ * 보험사 enum
+ *
+ * API 명세서 기준 보험사 ID와 표시명을 매핑한다.
+ */
+@Getter
+@AllArgsConstructor
+public enum InsuranceCompany {
+
+    SAMSUNG_FIRE("comp_001", "삼성화재"),
+    HYUNDAI_MARINE("comp_002", "현대해상"),
+    DB_INSURANCE("comp_003", "DB손해보험"),
+    KB_INSURANCE("comp_004", "KB손해보험"),
+    MERITZ_FIRE("comp_005", "메리츠화재"),
+    ETC("comp_006", "기타");
+
+    private final String id;
+    private final String displayName;
+
+    /**
+     * 보험사 ID로 enum 조회
+     *
+     * @param companyId 보험사 ID (예: "comp_001")
+     * @return 해당 보험사 enum
+     */
+    public static InsuranceCompany fromId(String companyId) {
+        for (InsuranceCompany company : values()) {
+            if (company.id.equals(companyId)) {
+                return company;
+            }
+        }
+        throw new BusinessException(ErrorCode.INSURANCE_COMPANY_NOT_FOUND);
+    }
+
+    /**
+     * 빅5 보험사 여부
+     */
+    public boolean isBigFive() {
+        return this != ETC;
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/enums/InsuranceGeneration.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/enums/InsuranceGeneration.java
@@ -34,13 +34,13 @@ public enum InsuranceGeneration {
     /**
      * 가입 연월로 세대 판별
      *
-     * @param subscribedYearMonth 가입 연월 (예: "2020-03")
+     * @param joinDate 가입 연월 (예: "2020-03")
      * @return 해당 세대 enum
      */
-    public static InsuranceGeneration from(String subscribedYearMonth) {
+    public static InsuranceGeneration from(String joinDate) {
         YearMonth target;
         try {
-            target = YearMonth.parse(subscribedYearMonth);
+            target = YearMonth.parse(joinDate);
         } catch (Exception e) {
             throw new BusinessException(ErrorCode.INVALID_SUBSCRIBED_DATE);
         }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/repository/InsuranceRepository.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/repository/InsuranceRepository.java
@@ -3,8 +3,15 @@ package com.silsonfit.silsonfit_api.domain.insurance.repository;
 import com.silsonfit.silsonfit_api.domain.insurance.entity.Insurance;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
+
 /**
  * 보험 상품 Repository
  */
 public interface InsuranceRepository extends JpaRepository<Insurance, Long> {
+
+    /**
+     * 보험사명 + 세대로 상품 목록 조회
+     */
+    List<Insurance> findByCompanyNameAndGeneration(String companyName, int generation);
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/repository/UserInsuranceRepository.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/repository/UserInsuranceRepository.java
@@ -22,4 +22,9 @@ public interface UserInsuranceRepository extends JpaRepository<UserInsurance, Lo
      * 사용자의 등록 보험 개수 조회
      */
     long countByUserId(Long userId);
+
+    /**
+     * 사용자의 동일 보험 상품 등록 여부 확인
+     */
+    boolean existsByUserIdAndInsuranceId(Long userId, Long insuranceId);
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
@@ -97,24 +97,20 @@ public class InsuranceService {
         return new InsuranceRegisterResponse(saved.getId());
     }
 
-    /**
-     * 보험 삭제
-     *
-     * @param userId 사용자 ID
-     * @param userInsuranceId 사용자 보험 등록 ID
-     */
+    // NOTE: 기능 명세에 보험 삭제 기능이 없어 주석 처리. 추후 필요 시 해제.
+    /*
     @Transactional
     public void delete(Long userId, Long userInsuranceId) {
         UserInsurance userInsurance = userInsuranceRepository.findById(userInsuranceId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_INSURANCE_NOT_FOUND));
 
-        // 본인 보험인지 검증
         if (!userInsurance.isOwnedBy(userId)) {
             throw new BusinessException(ErrorCode.USER_INSURANCE_ACCESS_DENIED);
         }
 
         userInsuranceRepository.delete(userInsurance);
     }
+    */
 
     /**
      * 보험사별 상품 목록 조회

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
@@ -3,6 +3,7 @@ package com.silsonfit.silsonfit_api.domain.insurance.service;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.GenerationRequest;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.GenerationResponse;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceInfoDto;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceProductResponse;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceRegisterRequest;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceRegisterResponse;
 import com.silsonfit.silsonfit_api.domain.insurance.entity.Insurance;
@@ -15,6 +16,8 @@ import com.silsonfit.silsonfit_api.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
 
 /**
  * 보험 관련 비즈니스 로직
@@ -93,6 +96,25 @@ public class InsuranceService {
         }
 
         userInsuranceRepository.delete(userInsurance);
+    }
+
+    /**
+     * 보험사별 상품 목록 조회
+     *
+     * @param companyName 보험사명
+     * @param generation 세대
+     * @return 상품 목록
+     */
+    @Transactional(readOnly = true)
+    public List<InsuranceProductResponse> getProducts(String companyName, int generation) {
+        List<Insurance> products = insuranceRepository.findByCompanyNameAndGeneration(companyName, generation);
+
+        return products.stream()
+                .map(insurance -> new InsuranceProductResponse(
+                        insurance.getId(),
+                        insurance.getProductName()
+                ))
+                .toList();
     }
 
     /**

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
@@ -149,7 +149,7 @@ public class InsuranceService {
 
         return userInsurances.stream()
                 .map(ui -> new UserInsuranceResponse(
-                        ui.getId(),
+                        ui.getId(), // 보험 등록 건의 고유 번호
                         ui.getInsurance().getCompanyName(),
                         ui.getInsurance().getProductName(),
                         ui.getInsurance().getGeneration(),

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
@@ -2,6 +2,7 @@ package com.silsonfit.silsonfit_api.domain.insurance.service;
 
 import com.silsonfit.silsonfit_api.domain.insurance.dto.GenerationRequest;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.GenerationResponse;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceCompanyResponse;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceInfoDto;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceProductResponse;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceRegisterRequest;
@@ -43,6 +44,22 @@ public class InsuranceService {
     public GenerationResponse determineGeneration(GenerationRequest request) {
         InsuranceGeneration gen = InsuranceGeneration.from(request.subscribedYearMonth());
         return new GenerationResponse(gen.getGeneration());
+    }
+
+    /**
+     * 보험사 목록 조회
+     *
+     * @return 빅5 보험사 + 기타 목록
+     */
+    public List<InsuranceCompanyResponse> getCompanies() {
+        return List.of(
+                new InsuranceCompanyResponse("samsung_fire", "삼성화재"),
+                new InsuranceCompanyResponse("hyundai_marine", "현대해상"),
+                new InsuranceCompanyResponse("db_insurance", "DB손해보험"),
+                new InsuranceCompanyResponse("kb_insurance", "KB손해보험"),
+                new InsuranceCompanyResponse("meritz_fire", "메리츠화재"),
+                new InsuranceCompanyResponse("etc", "기타")
+        );
     }
 
     /**

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
@@ -3,6 +3,8 @@ package com.silsonfit.silsonfit_api.domain.insurance.service;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.GenerationRequest;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.GenerationResponse;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceInfoDto;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceRegisterRequest;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceRegisterResponse;
 import com.silsonfit.silsonfit_api.domain.insurance.entity.Insurance;
 import com.silsonfit.silsonfit_api.domain.insurance.enums.InsuranceGeneration;
 import com.silsonfit.silsonfit_api.domain.insurance.entity.UserInsurance;
@@ -17,11 +19,13 @@ import org.springframework.transaction.annotation.Transactional;
 /**
  * 보험 관련 비즈니스 로직
  *
- * 세대 판별, 타 도메인 보험 정보 제공
+ * 세대 판별, 보험 등록/삭제, 상품 목록 조회, 타 도메인 보험 정보 제공
  */
 @Service
 @RequiredArgsConstructor
 public class InsuranceService {
+
+    private static final int MAX_INSURANCE_COUNT = 5;
 
     private final InsuranceRepository insuranceRepository;
     private final UserInsuranceRepository userInsuranceRepository;
@@ -35,6 +39,41 @@ public class InsuranceService {
     public GenerationResponse determineGeneration(GenerationRequest request) {
         InsuranceGeneration gen = InsuranceGeneration.from(request.subscribedYearMonth());
         return new GenerationResponse(gen.getGeneration());
+    }
+
+    /**
+     * 보험 등록
+     *
+     * @param userId 사용자 ID
+     * @param request 보험 등록 요청
+     * @return 등록된 사용자 보험 ID
+     */
+    @Transactional
+    public InsuranceRegisterResponse register(Long userId, InsuranceRegisterRequest request) {
+        // 최대 5개 제한 검증
+        long count = userInsuranceRepository.countByUserId(userId);
+        if (count >= MAX_INSURANCE_COUNT) {
+            throw new BusinessException(ErrorCode.INSURANCE_LIMIT_EXCEEDED);
+        }
+
+        // 동일 보험 상품 중복 등록 검증
+        if (userInsuranceRepository.existsByUserIdAndInsuranceId(userId, request.insuranceId())) {
+            throw new BusinessException(ErrorCode.INSURANCE_ALREADY_REGISTERED);
+        }
+
+        // 보험 상품 존재 여부 검증
+        Insurance insurance = insuranceRepository.findById(request.insuranceId())
+                .orElseThrow(() -> new BusinessException(ErrorCode.INSURANCE_NOT_FOUND));
+
+        UserInsurance userInsurance = UserInsurance.builder()
+                .userId(userId)
+                .insurance(insurance)
+                .subscribedAt(request.subscribedAt())
+                .hasNonCoveredRider(false)
+                .build();
+
+        UserInsurance saved = userInsuranceRepository.save(userInsurance);
+        return new InsuranceRegisterResponse(saved.getId());
     }
 
     /**

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
@@ -92,7 +92,7 @@ public class InsuranceService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_INSURANCE_NOT_FOUND));
 
         // 본인 보험인지 검증
-        if (!userInsurance.getUserId().equals(userId)) {
+        if (!userInsurance.isOwnedBy(userId)) {
             throw new BusinessException(ErrorCode.USER_INSURANCE_ACCESS_DENIED);
         }
 

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
@@ -9,6 +9,7 @@ import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceRegisterRequest
 import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceRegisterResponse;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.UserInsuranceResponse;
 import com.silsonfit.silsonfit_api.domain.insurance.entity.Insurance;
+import com.silsonfit.silsonfit_api.domain.insurance.enums.InsuranceCompany;
 import com.silsonfit.silsonfit_api.domain.insurance.enums.InsuranceGeneration;
 import com.silsonfit.silsonfit_api.domain.insurance.entity.UserInsurance;
 import com.silsonfit.silsonfit_api.domain.insurance.repository.InsuranceRepository;
@@ -19,6 +20,7 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
+import java.util.Arrays;
 import java.util.List;
 
 /**
@@ -38,11 +40,14 @@ public class InsuranceService {
     /**
      * 가입 연월 기반 세대 판별
      *
-     * @param request 가입 연월
-     * @return 세대 번호 및 설명
+     * @param request 보험사 ID + 가입 연월
+     * @return 세대 번호
      */
     public GenerationResponse determineGeneration(GenerationRequest request) {
-        InsuranceGeneration gen = InsuranceGeneration.from(request.subscribedYearMonth());
+        // 보험사 ID 유효성 검증
+        InsuranceCompany.fromId(request.companyId());
+
+        InsuranceGeneration gen = InsuranceGeneration.from(request.joinDate());
         return new GenerationResponse(gen.getGeneration());
     }
 
@@ -52,14 +57,9 @@ public class InsuranceService {
      * @return 빅5 보험사 + 기타 목록
      */
     public List<InsuranceCompanyResponse> getCompanies() {
-        return List.of(
-                new InsuranceCompanyResponse("samsung_fire", "삼성화재"),
-                new InsuranceCompanyResponse("hyundai_marine", "현대해상"),
-                new InsuranceCompanyResponse("db_insurance", "DB손해보험"),
-                new InsuranceCompanyResponse("kb_insurance", "KB손해보험"),
-                new InsuranceCompanyResponse("meritz_fire", "메리츠화재"),
-                new InsuranceCompanyResponse("etc", "기타")
-        );
+        return Arrays.stream(InsuranceCompany.values())
+                .map(company -> new InsuranceCompanyResponse(company.getId(), company.getDisplayName()))
+                .toList();
     }
 
     /**
@@ -119,13 +119,15 @@ public class InsuranceService {
     /**
      * 보험사별 상품 목록 조회
      *
-     * @param companyName 보험사명
+     * @param companyId 보험사 ID (예: "comp_001")
      * @param generation 세대
      * @return 상품 목록
      */
     @Transactional(readOnly = true)
-    public List<InsuranceProductResponse> getProducts(String companyName, int generation) {
-        List<Insurance> products = insuranceRepository.findByCompanyNameAndGeneration(companyName, generation);
+    public List<InsuranceProductResponse> getProducts(String companyId, int generation) {
+        InsuranceCompany company = InsuranceCompany.fromId(companyId);
+        List<Insurance> products = insuranceRepository.findByCompanyNameAndGeneration(
+                company.getDisplayName(), generation);
 
         return products.stream()
                 .map(insurance -> new InsuranceProductResponse(

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
@@ -6,6 +6,7 @@ import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceInfoDto;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceProductResponse;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceRegisterRequest;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceRegisterResponse;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.UserInsuranceResponse;
 import com.silsonfit.silsonfit_api.domain.insurance.entity.Insurance;
 import com.silsonfit.silsonfit_api.domain.insurance.enums.InsuranceGeneration;
 import com.silsonfit.silsonfit_api.domain.insurance.entity.UserInsurance;
@@ -113,6 +114,27 @@ public class InsuranceService {
                 .map(insurance -> new InsuranceProductResponse(
                         insurance.getId(),
                         insurance.getProductName()
+                ))
+                .toList();
+    }
+
+    /**
+     * 사용자 등록 보험 목록 조회
+     *
+     * @param userId 사용자 ID
+     * @return 등록 보험 목록
+     */
+    @Transactional(readOnly = true)
+    public List<UserInsuranceResponse> getMyInsurances(Long userId) {
+        List<UserInsurance> userInsurances = userInsuranceRepository.findByUserIdWithInsurance(userId);
+
+        return userInsurances.stream()
+                .map(ui -> new UserInsuranceResponse(
+                        ui.getId(),
+                        ui.getInsurance().getCompanyName(),
+                        ui.getInsurance().getProductName(),
+                        ui.getInsurance().getGeneration(),
+                        ui.getSubscribedAt()
                 ))
                 .toList();
     }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceService.java
@@ -77,6 +77,25 @@ public class InsuranceService {
     }
 
     /**
+     * 보험 삭제
+     *
+     * @param userId 사용자 ID
+     * @param userInsuranceId 사용자 보험 등록 ID
+     */
+    @Transactional
+    public void delete(Long userId, Long userInsuranceId) {
+        UserInsurance userInsurance = userInsuranceRepository.findById(userInsuranceId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_INSURANCE_NOT_FOUND));
+
+        // 본인 보험인지 검증
+        if (!userInsurance.getUserId().equals(userId)) {
+            throw new BusinessException(ErrorCode.USER_INSURANCE_ACCESS_DENIED);
+        }
+
+        userInsuranceRepository.delete(userInsurance);
+    }
+
+    /**
      * 타 도메인(계산/분석)에서 사용할 보험 정보 조회
      *
      * @param userInsuranceId 사용자 보험 등록 ID

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
@@ -44,6 +44,7 @@ public enum ErrorCode {
     FILE_DELETE_FAILED(500, "파일을 삭제하는 중 오류가 발생했습니다."),
 
     // ── Insurance ──
+    INSURANCE_COMPANY_NOT_FOUND(400, "존재하지 않는 보험사입니다."),
     INSURANCE_NOT_FOUND(404, "보험 상품을 찾을 수 없습니다."),
     USER_INSURANCE_NOT_FOUND(404, "등록된 보험을 찾을 수 없습니다."),
     INVALID_SUBSCRIBED_DATE(400, "세대를 판별할 수 없는 가입 연월입니다."),

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
@@ -47,6 +47,9 @@ public enum ErrorCode {
     INSURANCE_NOT_FOUND(404, "보험 상품을 찾을 수 없습니다."),
     USER_INSURANCE_NOT_FOUND(404, "등록된 보험을 찾을 수 없습니다."),
     INVALID_SUBSCRIBED_DATE(400, "세대를 판별할 수 없는 가입 연월입니다."),
+    INSURANCE_LIMIT_EXCEEDED(400, "보험은 최대 5개까지 등록할 수 있습니다."),
+    INSURANCE_ALREADY_REGISTERED(409, "이미 등록된 보험 상품입니다."),
+    USER_INSURANCE_ACCESS_DENIED(403, "해당 보험에 대한 접근 권한이 없습니다."),
 
     // ── Calculator ──
     COVERAGE_RULE_NOT_FOUND(404, "보장 룰을 찾을 수 없습니다."),

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceServiceTest.java
@@ -57,7 +57,7 @@ class InsuranceServiceTest {
     void determineGeneration_thirdGen() {
         // when
         GenerationResponse response = insuranceService.determineGeneration(
-                new GenerationRequest("2020-03"));
+                new GenerationRequest("comp_001", "2020-03"));
 
         // then
         assertThat(response.generation()).isEqualTo(3);
@@ -68,10 +68,21 @@ class InsuranceServiceTest {
     void determineGeneration_fourthGen() {
         // when
         GenerationResponse response = insuranceService.determineGeneration(
-                new GenerationRequest("2023-01"));
+                new GenerationRequest("comp_001", "2023-01"));
 
         // then
         assertThat(response.generation()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 보험사 ID로 세대 판별 시 INSURANCE_COMPANY_NOT_FOUND 예외")
+    void determineGeneration_invalidCompanyId() {
+        // when & then
+        assertThatThrownBy(() -> insuranceService.determineGeneration(
+                new GenerationRequest("comp_999", "2020-03")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INSURANCE_COMPANY_NOT_FOUND);
     }
 
     // ──────────── getInsuranceInfo ────────────
@@ -318,8 +329,8 @@ class InsuranceServiceTest {
         given(insuranceRepository.findByCompanyNameAndGeneration("삼성화재", 3))
                 .willReturn(products);
 
-        // when
-        List<InsuranceProductResponse> result = insuranceService.getProducts("삼성화재", 3);
+        // when — companyId "comp_001" → 내부적으로 "삼성화재"로 변환
+        List<InsuranceProductResponse> result = insuranceService.getProducts("comp_001", 3);
 
         // then
         assertThat(result).hasSize(2);
@@ -334,11 +345,21 @@ class InsuranceServiceTest {
         given(insuranceRepository.findByCompanyNameAndGeneration("기타", 1))
                 .willReturn(List.of());
 
-        // when
-        List<InsuranceProductResponse> result = insuranceService.getProducts("기타", 1);
+        // when — companyId "comp_006" → 내부적으로 "기타"로 변환
+        List<InsuranceProductResponse> result = insuranceService.getProducts("comp_006", 1);
 
         // then
         assertThat(result).isEmpty();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 보험사 ID로 상품 조회 시 INSURANCE_COMPANY_NOT_FOUND 예외")
+    void getProducts_invalidCompanyId() {
+        // when & then
+        assertThatThrownBy(() -> insuranceService.getProducts("comp_999", 3))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INSURANCE_COMPANY_NOT_FOUND);
     }
 
     // ──────────── getGenerationByInsuranceId ────────────

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceServiceTest.java
@@ -211,12 +211,11 @@ class InsuranceServiceTest {
                 .isEqualTo(ErrorCode.INSURANCE_NOT_FOUND);
     }
 
-    // ──────────── delete ────────────
-
+    // NOTE: 기능 명세에 보험 삭제 기능이 없어 주석 처리. 추후 필요 시 해제.
+    /*
     @Test
     @DisplayName("보험 삭제 성공")
     void delete_success() {
-        // given
         Insurance insurance = createInsurance(1L, "삼성화재", "삼성화재 실손의료비보험", 3);
         UserInsurance userInsurance = UserInsurance.builder()
                 .userId(1L)
@@ -228,20 +227,16 @@ class InsuranceServiceTest {
 
         given(userInsuranceRepository.findById(10L)).willReturn(Optional.of(userInsurance));
 
-        // when
         insuranceService.delete(1L, 10L);
 
-        // then
         verify(userInsuranceRepository).delete(userInsurance);
     }
 
     @Test
     @DisplayName("존재하지 않는 보험 삭제 시 USER_INSURANCE_NOT_FOUND 예외")
     void delete_notFound() {
-        // given
         given(userInsuranceRepository.findById(999L)).willReturn(Optional.empty());
 
-        // when & then
         assertThatThrownBy(() -> insuranceService.delete(1L, 999L))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
@@ -251,7 +246,6 @@ class InsuranceServiceTest {
     @Test
     @DisplayName("다른 사용자의 보험 삭제 시 USER_INSURANCE_ACCESS_DENIED 예외")
     void delete_accessDenied() {
-        // given
         Insurance insurance = createInsurance(1L, "삼성화재", "삼성화재 실손의료비보험", 3);
         UserInsurance userInsurance = UserInsurance.builder()
                 .userId(1L)
@@ -263,12 +257,12 @@ class InsuranceServiceTest {
 
         given(userInsuranceRepository.findById(10L)).willReturn(Optional.of(userInsurance));
 
-        // when & then
         assertThatThrownBy(() -> insuranceService.delete(2L, 10L))
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.USER_INSURANCE_ACCESS_DENIED);
     }
+    */
 
     // ──────────── getMyInsurances ────────────
 

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/insurance/service/InsuranceServiceTest.java
@@ -3,6 +3,10 @@ package com.silsonfit.silsonfit_api.domain.insurance.service;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.GenerationRequest;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.GenerationResponse;
 import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceInfoDto;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceProductResponse;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceRegisterRequest;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceRegisterResponse;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.UserInsuranceResponse;
 import com.silsonfit.silsonfit_api.domain.insurance.enums.CautionPoint;
 import com.silsonfit.silsonfit_api.domain.insurance.enums.ContractType;
 import com.silsonfit.silsonfit_api.domain.insurance.enums.CoverageStructure;
@@ -20,16 +24,19 @@ import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.test.util.ReflectionTestUtils;
 
+import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.BDDMockito.given;
+import static org.mockito.Mockito.verify;
 
 /**
  * InsuranceService 단위 테스트
  *
- * 세대 판별 및 보험 정보 조회 로직 검증
+ * 세대 판별, 보험 등록/삭제, 상품 목록 조회, 보험 정보 조회 로직 검증
  */
 @ExtendWith(MockitoExtension.class)
 class InsuranceServiceTest {
@@ -123,6 +130,217 @@ class InsuranceServiceTest {
                 .isEqualTo(ErrorCode.USER_INSURANCE_NOT_FOUND);
     }
 
+    // ──────────── register ────────────
+
+    @Test
+    @DisplayName("보험 등록 성공")
+    void register_success() {
+        // given
+        Insurance insurance = createInsurance(1L, "삼성화재", "삼성화재 실손의료비보험", 3);
+
+        given(userInsuranceRepository.countByUserId(1L)).willReturn(0L);
+        given(userInsuranceRepository.existsByUserIdAndInsuranceId(1L, 1L)).willReturn(false);
+        given(insuranceRepository.findById(1L)).willReturn(Optional.of(insurance));
+        given(userInsuranceRepository.save(any(UserInsurance.class))).willAnswer(invocation -> {
+            UserInsurance saved = invocation.getArgument(0);
+            ReflectionTestUtils.setField(saved, "id", 10L);
+            return saved;
+        });
+
+        // when
+        InsuranceRegisterResponse response = insuranceService.register(
+                1L, new InsuranceRegisterRequest(1L, "2020-03"));
+
+        // then
+        assertThat(response.userInsuranceId()).isEqualTo(10L);
+    }
+
+    @Test
+    @DisplayName("보험 5개 초과 등록 시 INSURANCE_LIMIT_EXCEEDED 예외")
+    void register_limitExceeded() {
+        // given
+        given(userInsuranceRepository.countByUserId(1L)).willReturn(5L);
+
+        // when & then
+        assertThatThrownBy(() -> insuranceService.register(
+                1L, new InsuranceRegisterRequest(1L, "2020-03")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INSURANCE_LIMIT_EXCEEDED);
+    }
+
+    @Test
+    @DisplayName("동일 보험 상품 중복 등록 시 INSURANCE_ALREADY_REGISTERED 예외")
+    void register_alreadyRegistered() {
+        // given
+        given(userInsuranceRepository.countByUserId(1L)).willReturn(1L);
+        given(userInsuranceRepository.existsByUserIdAndInsuranceId(1L, 1L)).willReturn(true);
+
+        // when & then
+        assertThatThrownBy(() -> insuranceService.register(
+                1L, new InsuranceRegisterRequest(1L, "2020-03")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INSURANCE_ALREADY_REGISTERED);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 보험 상품 등록 시 INSURANCE_NOT_FOUND 예외")
+    void register_insuranceNotFound() {
+        // given
+        given(userInsuranceRepository.countByUserId(1L)).willReturn(0L);
+        given(userInsuranceRepository.existsByUserIdAndInsuranceId(1L, 999L)).willReturn(false);
+        given(insuranceRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> insuranceService.register(
+                1L, new InsuranceRegisterRequest(999L, "2020-03")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.INSURANCE_NOT_FOUND);
+    }
+
+    // ──────────── delete ────────────
+
+    @Test
+    @DisplayName("보험 삭제 성공")
+    void delete_success() {
+        // given
+        Insurance insurance = createInsurance(1L, "삼성화재", "삼성화재 실손의료비보험", 3);
+        UserInsurance userInsurance = UserInsurance.builder()
+                .userId(1L)
+                .insurance(insurance)
+                .subscribedAt("2020-03")
+                .hasNonCoveredRider(false)
+                .build();
+        ReflectionTestUtils.setField(userInsurance, "id", 10L);
+
+        given(userInsuranceRepository.findById(10L)).willReturn(Optional.of(userInsurance));
+
+        // when
+        insuranceService.delete(1L, 10L);
+
+        // then
+        verify(userInsuranceRepository).delete(userInsurance);
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 보험 삭제 시 USER_INSURANCE_NOT_FOUND 예외")
+    void delete_notFound() {
+        // given
+        given(userInsuranceRepository.findById(999L)).willReturn(Optional.empty());
+
+        // when & then
+        assertThatThrownBy(() -> insuranceService.delete(1L, 999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_INSURANCE_NOT_FOUND);
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 보험 삭제 시 USER_INSURANCE_ACCESS_DENIED 예외")
+    void delete_accessDenied() {
+        // given
+        Insurance insurance = createInsurance(1L, "삼성화재", "삼성화재 실손의료비보험", 3);
+        UserInsurance userInsurance = UserInsurance.builder()
+                .userId(1L)
+                .insurance(insurance)
+                .subscribedAt("2020-03")
+                .hasNonCoveredRider(false)
+                .build();
+        ReflectionTestUtils.setField(userInsurance, "id", 10L);
+
+        given(userInsuranceRepository.findById(10L)).willReturn(Optional.of(userInsurance));
+
+        // when & then
+        assertThatThrownBy(() -> insuranceService.delete(2L, 10L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.USER_INSURANCE_ACCESS_DENIED);
+    }
+
+    // ──────────── getMyInsurances ────────────
+
+    @Test
+    @DisplayName("내 보험 목록 조회 성공")
+    void getMyInsurances_success() {
+        // given
+        Insurance insurance1 = createInsurance(1L, "삼성화재", "삼성화재 실손의료비보험", 3);
+        Insurance insurance2 = createInsurance(2L, "현대해상", "현대해상 실손의료비보험", 4);
+
+        UserInsurance ui1 = UserInsurance.builder()
+                .userId(1L).insurance(insurance1).subscribedAt("2020-03").hasNonCoveredRider(false).build();
+        ReflectionTestUtils.setField(ui1, "id", 10L);
+
+        UserInsurance ui2 = UserInsurance.builder()
+                .userId(1L).insurance(insurance2).subscribedAt("2023-01").hasNonCoveredRider(false).build();
+        ReflectionTestUtils.setField(ui2, "id", 11L);
+
+        given(userInsuranceRepository.findByUserIdWithInsurance(1L))
+                .willReturn(List.of(ui1, ui2));
+
+        // when
+        List<UserInsuranceResponse> result = insuranceService.getMyInsurances(1L);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).companyName()).isEqualTo("삼성화재");
+        assertThat(result.get(0).joinDate()).isEqualTo("2020-03");
+        assertThat(result.get(1).companyName()).isEqualTo("현대해상");
+        assertThat(result.get(1).generation()).isEqualTo(4);
+    }
+
+    @Test
+    @DisplayName("등록된 보험이 없으면 빈 목록 반환")
+    void getMyInsurances_empty() {
+        // given
+        given(userInsuranceRepository.findByUserIdWithInsurance(1L))
+                .willReturn(List.of());
+
+        // when
+        List<UserInsuranceResponse> result = insuranceService.getMyInsurances(1L);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
+    // ──────────── getProducts ────────────
+
+    @Test
+    @DisplayName("보험사별 상품 목록 조회 성공")
+    void getProducts_success() {
+        // given
+        List<Insurance> products = List.of(
+                createInsurance(1L, "삼성화재", "무배당 삼성화재 실손의료비보험 3세대", 3),
+                createInsurance(2L, "삼성화재", "무배당 삼성화재 유병력자 실손의료비보험 3세대", 3)
+        );
+
+        given(insuranceRepository.findByCompanyNameAndGeneration("삼성화재", 3))
+                .willReturn(products);
+
+        // when
+        List<InsuranceProductResponse> result = insuranceService.getProducts("삼성화재", 3);
+
+        // then
+        assertThat(result).hasSize(2);
+        assertThat(result.get(0).productName()).isEqualTo("무배당 삼성화재 실손의료비보험 3세대");
+        assertThat(result.get(1).productName()).isEqualTo("무배당 삼성화재 유병력자 실손의료비보험 3세대");
+    }
+
+    @Test
+    @DisplayName("상품이 없는 보험사/세대 조회 시 빈 목록 반환")
+    void getProducts_empty() {
+        // given
+        given(insuranceRepository.findByCompanyNameAndGeneration("기타", 1))
+                .willReturn(List.of());
+
+        // when
+        List<InsuranceProductResponse> result = insuranceService.getProducts("기타", 1);
+
+        // then
+        assertThat(result).isEmpty();
+    }
+
     // ──────────── getGenerationByInsuranceId ────────────
 
     @Test
@@ -159,5 +377,20 @@ class InsuranceServiceTest {
                 .isInstanceOf(BusinessException.class)
                 .extracting(e -> ((BusinessException) e).getErrorCode())
                 .isEqualTo(ErrorCode.INSURANCE_NOT_FOUND);
+    }
+
+    // ──────────── helper ────────────
+
+    private Insurance createInsurance(Long id, String companyName, String productName, int generation) {
+        Insurance insurance = Insurance.builder()
+                .companyName(companyName)
+                .productName(productName)
+                .contractType(ContractType.INDIVIDUAL)
+                .generation(generation)
+                .coverageStructure(CoverageStructure.COVERED_AND_UNCOVERED)
+                .cautionPoint(CautionPoint.RENEWAL_TYPE)
+                .build();
+        ReflectionTestUtils.setField(insurance, "id", id);
+        return insurance;
     }
 }


### PR DESCRIPTION
<!-- PR의 타입은 Label을 통해 나타내주세요. -->

### 💻 작업 내용
<!-- 진행한 작업 내용에 대해 작성해주세요. -->
- 보험 등록/삭제/상품 목록 조회/내 보험 목록 조회 API 구현
- 소유권 검증 로직 엔티티 캡슐화
- 보험사 목록 조회 API 구현
- 서비스 단위 테스트 작성 
- 보험사명을 enum으로 작성해서 반환
- 명세서를 기준으로 누락되거나 네이밍 불일치한 부분 수정

### ✨ 리뷰 포인트
<!-- (ex) query 가 너무 복잡한 것 같은데 이 위주로 봐주세요. -->
- 보험 등록 시 최대 5개 제한 → 중복 등록 방지 → 상품 존재 확인 순서로 검증이 적절한지
- 삭제 시 소유권 검증을 엔티티 메서드(isOwnedBy)로 분리했는데 이 방식이 괜찮은지
 
### 📝 메모
<!-- PR 관련 전달사항이 있다면 이곳에 작성해주세요. -->
- 보험 상세 조회 API는 현재 와이어프레임 기준으로 보험 약관 분석 정보가 들어가 있더라구요. 그렇다면 사용자가 분석 요청을 하지 않아도 등록한 보험은 약관 분석을 해야 하는지 이 부분에 대해서 팀 회의 때 물어보고 추가로 진행할 예정입니다.
- 상품 목록 조회는 로직만 구현된 상태이고 seed 데이터는 약관 PDF 수집 후 추가 예정입니다.
- 현재 중복 등록 방지는 애플리케이션 레벨에서 처리하고 있습니다. DB UNIQUE 제약(user_id, insuurance_id) 추가도 고려하고 있고, 기능 동작에는 문제없어 고도화 때 진행할 생각입니다.

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
closed #39 
