### PR TITLE
fix(user): 내 정보 조회 응답에 프로필 이미지 URL 누락 수정

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/dto/UserResponse.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/dto/UserResponse.java
@@ -6,6 +6,7 @@ package com.silsonfit.silsonfit_api.domain.user.dto;
 public record UserResponse(
         Long userId,
         String name,
-        String email
+        String email,
+        String profileImageUrl
 ) {
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/service/UserService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/service/UserService.java
@@ -28,7 +28,7 @@ public class UserService {
         User user = userRepository.findById(userId)
                 .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
 
-        return new UserResponse(user.getId(), user.getName(), user.getEmail());
+        return new UserResponse(user.getId(), user.getName(), user.getEmail(), user.getProfileImageUrl());
     }
 
     /**

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/user/service/UserServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/user/service/UserServiceTest.java
@@ -54,6 +54,7 @@ class UserServiceTest {
         assertThat(response.userId()).isEqualTo(1L);
         assertThat(response.name()).isEqualTo("홍길동");
         assertThat(response.email()).isEqualTo("hong@test.com");
+        assertThat(response.profileImageUrl()).isEqualTo("https://k.kakaocdn.net/test.jpg");
     }
 
     @Test
@@ -119,6 +120,7 @@ class UserServiceTest {
                 .socialId(socialId)
                 .name(name)
                 .email(email)
+                .profileImageUrl("https://k.kakaocdn.net/test.jpg")
                 .build();
         ReflectionTestUtils.setField(user, "id", id);
         return user;


### PR DESCRIPTION
<!-- PR의 타입은 Label을 통해 나타내주세요. -->

### 💻 작업 내용
<!-- 진행한 작업 내용에 대해 작성해주세요. -->
- 내 정보 조회 API 응답에 profileImageUrl 필드 추가 

### 📝 메모
<!-- PR 관련 전달사항이 있다면 이곳에 작성해주세요. -->
- UserResponse에 profileImageUrl이 누락되어 프론트에서 프로필 이미지를 표시할 수 없었습니다.

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
closed #44 
