### PR TITLE
feat: 공공 EDI 수가 조회 Client 구현

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/client/FakeEdiCodeClient.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/client/FakeEdiCodeClient.java
@@ -3,6 +3,7 @@ package com.silsonfit.silsonfit_api.domain.calculation.client;
 import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.FeeType;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.PayType;
+import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 import java.math.BigDecimal;
@@ -13,9 +14,9 @@ import java.util.Optional;
  * 공공 EDI API Fake Client
  *
  * - 실제 공공 API 연동 전까지 DB 미존재 EDI 코드 조회 흐름을 검증하기 위한 임시 구현체다.
- * TODO(calculation): 실제 공공 API Client 구현 시 한방수가/진료수가/약국수가 API 응답을 EdiCode로 매핑한다.
  */
 @Component
+@Profile("!prod & !real-edi")
 public class FakeEdiCodeClient implements EdiCodeClient {
 
     @Override

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/client/PublicEdiCodeClient.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/client/PublicEdiCodeClient.java
@@ -34,31 +34,34 @@ import java.util.Optional;
 @Profile("prod | real-edi")
 public class PublicEdiCodeClient implements EdiCodeClient {
 
-    private static final int DEFAULT_PAGE_SIZE = 10;
-    private static final int DEFAULT_PAGE_NO = 1;
     private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+    private static final List<Endpoint> ENDPOINTS = List.of(
+            new Endpoint("/getDiagnossMdfeeList", FeeType.MEDICAL),
+            new Endpoint("/getCmdcMdfeeList", FeeType.KOREAN_MEDICAL),
+            new Endpoint("/getPharmacyMdfeeList", FeeType.PHARMACY)
+    );
 
     private final String serviceKey;
+    private final int numOfRow;
+    private final int pageNo;
     private final RestClient restClient;
-    private final List<Endpoint> endpoints;
 
     public PublicEdiCodeClient(
             @Value("${edi.public-api.service-key}") String serviceKey,
             @Value("${edi.public-api.endpoint}") String endpoint,
+            @Value("${edi.public-api.num-of-row}") int numOfRow,
+            @Value("${edi.public-api.page-no}") int pageNo,
             RestClient.Builder restClientBuilder
     ) {
         this.serviceKey = serviceKey;
+        this.numOfRow = numOfRow;
+        this.pageNo = pageNo;
         this.restClient = restClientBuilder.baseUrl(endpoint).build();
-        this.endpoints = List.of(
-                new Endpoint("/getDiagnossMdfeeList", FeeType.MEDICAL),
-                new Endpoint("/getCmdcMdfeeList", FeeType.KOREAN_MEDICAL),
-                new Endpoint("/getPharmacyMdfeeList", FeeType.PHARMACY)
-        );
     }
 
     @Override
     public Optional<EdiCode> fetchByCode(String code) {
-        for (Endpoint endpoint : endpoints) {
+        for (Endpoint endpoint : ENDPOINTS) {
             Optional<EdiCode> ediCode = fetchByEndpoint(code, endpoint);
 
             if (ediCode.isPresent()) {
@@ -69,14 +72,17 @@ public class PublicEdiCodeClient implements EdiCodeClient {
         return Optional.empty();
     }
 
-    private Optional<EdiCode> fetchByEndpoint(String code, Endpoint endpoint) {
+    private Optional<EdiCode> fetchByEndpoint(
+            String code,
+            Endpoint endpoint
+    ) {
         try {
             String response = restClient.get()
                     .uri(uriBuilder -> uriBuilder
                             .path(endpoint.path())
                             .queryParam("serviceKey", serviceKey)
-                            .queryParam("numOfRow", DEFAULT_PAGE_SIZE)
-                            .queryParam("pageNo", DEFAULT_PAGE_NO)
+                            .queryParam("numOfRow", numOfRow)
+                            .queryParam("pageNo", pageNo)
                             .queryParam("mdfeeCd", code)
                             .build()
                     )

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/client/PublicEdiCodeClient.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/client/PublicEdiCodeClient.java
@@ -1,0 +1,184 @@
+package com.silsonfit.silsonfit_api.domain.calculation.client;
+
+import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.FeeType;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.PayType;
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+import org.springframework.web.client.RestClient;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.Node;
+import org.w3c.dom.NodeList;
+import org.xml.sax.InputSource;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.StringReader;
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * 공공데이터포털 EDI 수가 코드 조회 Client
+ *
+ * - 진료수가/한방수가/약국수가 API를 순차 조회한다.
+ * - XML 응답의 첫 번째 item을 EdiCode로 매핑한다.
+ */
+@Component
+@Profile("prod | real-edi")
+public class PublicEdiCodeClient implements EdiCodeClient {
+
+    private static final int DEFAULT_PAGE_SIZE = 10;
+    private static final int DEFAULT_PAGE_NO = 1;
+    private static final DateTimeFormatter DATE_FORMATTER = DateTimeFormatter.ofPattern("yyyyMMdd");
+
+    private final String serviceKey;
+    private final RestClient restClient;
+    private final List<Endpoint> endpoints;
+
+    public PublicEdiCodeClient(
+            @Value("${edi.public-api.service-key}") String serviceKey,
+            @Value("${edi.public-api.endpoint}") String endpoint,
+            RestClient.Builder restClientBuilder
+    ) {
+        this.serviceKey = serviceKey;
+        this.restClient = restClientBuilder.baseUrl(endpoint).build();
+        this.endpoints = List.of(
+                new Endpoint("/getDiagnossMdfeeList", FeeType.MEDICAL),
+                new Endpoint("/getCmdcMdfeeList", FeeType.KOREAN_MEDICAL),
+                new Endpoint("/getPharmacyMdfeeList", FeeType.PHARMACY)
+        );
+    }
+
+    @Override
+    public Optional<EdiCode> fetchByCode(String code) {
+        for (Endpoint endpoint : endpoints) {
+            Optional<EdiCode> ediCode = fetchByEndpoint(code, endpoint);
+
+            if (ediCode.isPresent()) {
+                return ediCode;
+            }
+        }
+
+        return Optional.empty();
+    }
+
+    private Optional<EdiCode> fetchByEndpoint(String code, Endpoint endpoint) {
+        try {
+            String response = restClient.get()
+                    .uri(uriBuilder -> uriBuilder
+                            .path(endpoint.path())
+                            .queryParam("serviceKey", serviceKey)
+                            .queryParam("numOfRow", DEFAULT_PAGE_SIZE)
+                            .queryParam("pageNo", DEFAULT_PAGE_NO)
+                            .queryParam("mdfeeCd", code)
+                            .build()
+                    )
+                    .retrieve()
+                    .body(String.class);
+
+            return parse(response, endpoint.feeType());
+        } catch (BusinessException e) {
+            throw e;
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.EDI_API_SERVER_ERROR);
+        }
+    }
+
+    private Optional<EdiCode> parse(String response, FeeType feeType) {
+        if (response == null || response.isBlank()) {
+            return Optional.empty();
+        }
+
+        try {
+            DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+            factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+            factory.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+            factory.setExpandEntityReferences(false);
+
+            Document document = factory.newDocumentBuilder()
+                    .parse(new InputSource(new StringReader(response)));
+            NodeList items = document.getElementsByTagName("item");
+
+            if (items.getLength() == 0) {
+                return Optional.empty();
+            }
+
+            Element item = (Element) items.item(0);
+
+            return Optional.of(EdiCode.create(
+                    text(item, "mdfeeCd"),
+                    text(item, "korNm"),
+                    text(item, "mdfeeDivNo"),
+                    parsePayType(text(item, "payTpNm")),
+                    parseInteger(text(item, "unprc")),
+                    parseBigDecimal(text(item, "cvalPnt")),
+                    parseDate(text(item, "adtstaDd")),
+                    feeType
+            ));
+        } catch (Exception e) {
+            throw new BusinessException(ErrorCode.EDI_API_SERVER_ERROR);
+        }
+    }
+
+    private PayType parsePayType(String value) {
+        if ("급여".equals(value)) {
+            return PayType.PAY;
+        }
+
+        return PayType.NON_PAY;
+    }
+
+    private Integer parseInteger(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        return Integer.valueOf(value.replace(",", ""));
+    }
+
+    private BigDecimal parseBigDecimal(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        return new BigDecimal(value.replace(",", ""));
+    }
+
+    private LocalDate parseDate(String value) {
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        return LocalDate.parse(value, DATE_FORMATTER);
+    }
+
+    private String text(Element element, String tagName) {
+        NodeList nodes = element.getElementsByTagName(tagName);
+
+        if (nodes.getLength() == 0) {
+            return null;
+        }
+
+        Node node = nodes.item(0);
+        String value = node.getTextContent();
+
+        if (value == null || value.isBlank()) {
+            return null;
+        }
+
+        return value.trim();
+    }
+
+    private record Endpoint(
+            String path,
+            FeeType feeType
+    ) {
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/controller/DevEdiCodeController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/controller/DevEdiCodeController.java
@@ -1,0 +1,71 @@
+package com.silsonfit.silsonfit_api.domain.calculation.controller;
+
+import com.silsonfit.silsonfit_api.domain.calculation.client.EdiCodeClient;
+import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.FeeType;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.PayType;
+import com.silsonfit.silsonfit_api.global.common.ApiResponse;
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+
+/**
+ * 개발용 EDI 코드 조회 API
+ *
+ * - real-edi profile에서만 활성화되고, prod profile에서는 비활성화된다.
+ * - 실제 공공 EDI API 연동 상태를 확인하기 위한 임시 API다.
+ */
+@Profile("real-edi & !prod")
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/dev/edi-codes")
+public class DevEdiCodeController {
+
+    private final EdiCodeClient ediCodeClient;
+
+    /**
+     * 외부 EDI Client 직접 조회
+     */
+    @GetMapping("/{code}")
+    public ApiResponse<DevEdiCodeResponse> getEdiCode(
+            @PathVariable String code
+    ) {
+        EdiCode ediCode = ediCodeClient.fetchByCode(code)
+                .orElseThrow(() -> new BusinessException(ErrorCode.EDI_CODE_NOT_FOUND));
+
+        return ApiResponse.success(DevEdiCodeResponse.from(ediCode));
+    }
+
+    public record DevEdiCodeResponse(
+            String code,
+            String treatmentName,
+            String feeDivisionNumber,
+            PayType payType,
+            Integer unitPrice,
+            BigDecimal relativeValuePoint,
+            LocalDate effectiveStartDate,
+            FeeType feeType
+    ) {
+
+        public static DevEdiCodeResponse from(EdiCode ediCode) {
+            return new DevEdiCodeResponse(
+                    ediCode.getCode(),
+                    ediCode.getTreatmentName(),
+                    ediCode.getFeeDivisionNumber(),
+                    ediCode.getPayType(),
+                    ediCode.getUnitPrice(),
+                    ediCode.getRelativeValuePoint(),
+                    ediCode.getEffectiveStartDate(),
+                    ediCode.getFeeType()
+            );
+        }
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/SecurityConfig.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/SecurityConfig.java
@@ -61,6 +61,7 @@ public class SecurityConfig {
                                 "/swagger-ui/**",
                                 "/swagger-ui.html",
                                 "/v3/api-docs/**",
+                                "/api/dev/**",
                                 "/actuator/health",
                                 "/actuator/info",
                                 "/api/sse/connect",

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
@@ -51,6 +51,7 @@ public enum ErrorCode {
     // ── Calculator ──
     COVERAGE_RULE_NOT_FOUND(404, "보장 룰을 찾을 수 없습니다."),
     EDI_CODE_NOT_FOUND(404, "EDI 코드를 찾을 수 없습니다."),
+    EDI_API_SERVER_ERROR(502, "공공 EDI API 통신에 실패했습니다."),
 
     ;
 

--- a/silsonfit-api/src/main/resources/application-prod.yml
+++ b/silsonfit-api/src/main/resources/application-prod.yml
@@ -32,6 +32,10 @@ aws:
     region: ap-northeast-2
     bucket: silsonfit-bucket-594754931983-ap-northeast-2-an
 
+edi:
+  public-api:
+    service-key: ${EDI_PUBLIC_API_SERVICE_KEY}
+
 management:
   endpoint:
     health:

--- a/silsonfit-api/src/main/resources/application-real-edi.yml
+++ b/silsonfit-api/src/main/resources/application-real-edi.yml
@@ -1,0 +1,3 @@
+edi:
+  public-api:
+    service-key: ${EDI_PUBLIC_API_SERVICE_KEY}

--- a/silsonfit-api/src/main/resources/application.yml
+++ b/silsonfit-api/src/main/resources/application.yml
@@ -15,6 +15,11 @@ jwt:
 kakao:
   user-info-uri: https://kapi.kakao.com/v2/user/me
 
+edi:
+  public-api:
+    endpoint: https://apis.data.go.kr/B551182/mdfeeCrtrInfoService
+    service-key: ${EDI_PUBLIC_API_SERVICE_KEY:}
+
 management:
   endpoints:
     web:

--- a/silsonfit-api/src/main/resources/application.yml
+++ b/silsonfit-api/src/main/resources/application.yml
@@ -19,6 +19,8 @@ edi:
   public-api:
     endpoint: https://apis.data.go.kr/B551182/mdfeeCrtrInfoService
     service-key: ${EDI_PUBLIC_API_SERVICE_KEY:}
+    num-of-row: 10
+    page-no: 1
 
 management:
   endpoints:

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/client/PublicEdiCodeClientTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/client/PublicEdiCodeClientTest.java
@@ -39,7 +39,7 @@ class PublicEdiCodeClientTest {
     void setUp() {
         RestClient.Builder builder = RestClient.builder();
         this.server = MockRestServiceServer.bindTo(builder).build();
-        this.publicEdiCodeClient = new PublicEdiCodeClient(SERVICE_KEY, ENDPOINT, builder);
+        this.publicEdiCodeClient = new PublicEdiCodeClient(SERVICE_KEY, ENDPOINT, 10, 1, builder);
     }
 
     @Test
@@ -133,4 +133,5 @@ class PublicEdiCodeClientTest {
                 </response>
                 """;
     }
+
 }

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/client/PublicEdiCodeClientTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/client/PublicEdiCodeClientTest.java
@@ -1,0 +1,136 @@
+package com.silsonfit.silsonfit_api.domain.calculation.client;
+
+import com.silsonfit.silsonfit_api.domain.calculation.entity.EdiCode;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.FeeType;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.PayType;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.http.HttpMethod;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.client.MockRestServiceServer;
+import org.springframework.web.client.RestClient;
+
+import java.math.BigDecimal;
+import java.time.LocalDate;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.method;
+import static org.springframework.test.web.client.match.MockRestRequestMatchers.requestTo;
+import static org.springframework.test.web.client.response.MockRestResponseCreators.withSuccess;
+
+/**
+ * PublicEdiCodeClient 테스트
+ *
+ * MockRestServiceServer로 공공 EDI API XML 응답을 스텁 후
+ * RestClient 호출 → XML 파싱 → EdiCode 반환 흐름을 검증한다.
+ */
+class PublicEdiCodeClientTest {
+
+    private static final String ENDPOINT = "https://apis.data.go.kr/B551182/mdfeeCrtrInfoService";
+    private static final String SERVICE_KEY = "test-service-key";
+    private static final MediaType XML_UTF_8 = MediaType.parseMediaType("application/xml;charset=UTF-8");
+
+    private MockRestServiceServer server;
+    private PublicEdiCodeClient publicEdiCodeClient;
+
+    @BeforeEach
+    void setUp() {
+        RestClient.Builder builder = RestClient.builder();
+        this.server = MockRestServiceServer.bindTo(builder).build();
+        this.publicEdiCodeClient = new PublicEdiCodeClient(SERVICE_KEY, ENDPOINT, builder);
+    }
+
+    @Test
+    @DisplayName("진료수가 XML 응답을 EdiCode로 매핑한다")
+    void fetchByCode_medical_success() {
+        server.expect(requestTo(ENDPOINT + "/getDiagnossMdfeeList?serviceKey=test-service-key&numOfRow=10&pageNo=1&mdfeeCd=MRI001"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("""
+                        <response>
+                            <body>
+                                <items>
+                                    <item>
+                                        <adtstaDd>20260101</adtstaDd>
+                                        <cvalPnt>123.45</cvalPnt>
+                                        <korNm>MRI 검사</korNm>
+                                        <mdfeeCd>MRI001</mdfeeCd>
+                                        <mdfeeDivNo>MRI</mdfeeDivNo>
+                                        <payTpNm>급여</payTpNm>
+                                        <unprc>100000</unprc>
+                                    </item>
+                                </items>
+                            </body>
+                        </response>
+                        """, XML_UTF_8));
+
+        Optional<EdiCode> result = publicEdiCodeClient.fetchByCode("MRI001");
+
+        assertThat(result).isPresent();
+        EdiCode ediCode = result.get();
+        assertThat(ediCode.getCode()).isEqualTo("MRI001");
+        assertThat(ediCode.getTreatmentName()).isEqualTo("MRI 검사");
+        assertThat(ediCode.getFeeDivisionNumber()).isEqualTo("MRI");
+        assertThat(ediCode.getPayType()).isEqualTo(PayType.PAY);
+        assertThat(ediCode.getUnitPrice()).isEqualTo(100000);
+        assertThat(ediCode.getRelativeValuePoint()).isEqualByComparingTo(BigDecimal.valueOf(123.45));
+        assertThat(ediCode.getEffectiveStartDate()).isEqualTo(LocalDate.of(2026, 1, 1));
+        assertThat(ediCode.getFeeType()).isEqualTo(FeeType.MEDICAL);
+        server.verify();
+    }
+
+    @Test
+    @DisplayName("진료/한방수가에 결과가 없으면 약국수가 응답을 EdiCode로 매핑한다")
+    void fetchByCode_fallback_to_pharmacy() {
+        server.expect(requestTo(ENDPOINT + "/getDiagnossMdfeeList?serviceKey=test-service-key&numOfRow=10&pageNo=1&mdfeeCd=Z3000030"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(emptyItemsXml(), XML_UTF_8));
+        server.expect(requestTo(ENDPOINT + "/getCmdcMdfeeList?serviceKey=test-service-key&numOfRow=10&pageNo=1&mdfeeCd=Z3000030"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess(emptyItemsXml(), XML_UTF_8));
+        server.expect(requestTo(ENDPOINT + "/getPharmacyMdfeeList?serviceKey=test-service-key&numOfRow=10&pageNo=1&mdfeeCd=Z3000030"))
+                .andExpect(method(HttpMethod.GET))
+                .andRespond(withSuccess("""
+                        <response>
+                            <body>
+                                <items>
+                                    <item>
+                                        <adtstaDd>20160101</adtstaDd>
+                                        <cvalPnt>3.3</cvalPnt>
+                                        <korNm>복약지도료(방문당)-토요09-13</korNm>
+                                        <mdfeeCd>Z3000030</mdfeeCd>
+                                        <mdfeeDivNo>약</mdfeeDivNo>
+                                        <payTpNm>급여</payTpNm>
+                                        <unprc>260</unprc>
+                                    </item>
+                                </items>
+                            </body>
+                        </response>
+                        """, XML_UTF_8));
+
+        Optional<EdiCode> result = publicEdiCodeClient.fetchByCode("Z3000030");
+
+        assertThat(result).isPresent();
+        EdiCode ediCode = result.get();
+        assertThat(ediCode.getCode()).isEqualTo("Z3000030");
+        assertThat(ediCode.getTreatmentName()).isEqualTo("복약지도료(방문당)-토요09-13");
+        assertThat(ediCode.getFeeDivisionNumber()).isEqualTo("약");
+        assertThat(ediCode.getPayType()).isEqualTo(PayType.PAY);
+        assertThat(ediCode.getUnitPrice()).isEqualTo(260);
+        assertThat(ediCode.getRelativeValuePoint()).isEqualByComparingTo(BigDecimal.valueOf(3.3));
+        assertThat(ediCode.getEffectiveStartDate()).isEqualTo(LocalDate.of(2016, 1, 1));
+        assertThat(ediCode.getFeeType()).isEqualTo(FeeType.PHARMACY);
+        server.verify();
+    }
+
+    private String emptyItemsXml() {
+        return """
+                <response>
+                    <body>
+                        <items/>
+                    </body>
+                </response>
+                """;
+    }
+}


### PR DESCRIPTION
### 💻 작업 내용

* 공공 EDI 수가 조회 Client 구현
* XML 응답 → 내부 객체(EdiCode) 매핑 로직 구현
* 실제 호출 확인용 dev API 추가
* EDI Client 설정값 하드코딩 제거 및 설정 외부화
* XML 매핑 검증 테스트 추가

### ✨ 리뷰 포인트

* 외부 EDI 응답(XML) → 내부 도메인(EdiCode) 매핑 정확성
* Client 계층이 Domain/Service와 적절히 분리되어 있는지
* 설정값 외부화 방식(application.yml 등)이 운영 환경에 적합한지
* 외부 API 실패 시 예외 처리/확장 가능성

### 📝 메모

* 현재는 공공 EDI API 기반 조회를 단순 연동한 상태이며, 재시도/타임아웃/캐싱 전략은 추후 개선 예정입니다.
* dev API는 실제 호출 확인 용도로만 사용됩니다.
* 추후에 비밀키 관리에 대해서도 논의해봐야할 것 같습니다.

### 🎯 관련 이슈

closed #32 