### PR TITLE
feat: 보험 계산 이력 조회 API 구현

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationHistoryController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationHistoryController.java
@@ -1,0 +1,45 @@
+package com.silsonfit.silsonfit_api.domain.calculation.controller;
+
+import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationHistoryListResponse;
+import com.silsonfit.silsonfit_api.domain.calculation.service.CalculationHistoryService;
+import com.silsonfit.silsonfit_api.global.auth.CustomUserDetails;
+import com.silsonfit.silsonfit_api.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.Pageable;
+import org.springframework.data.web.PageableDefault;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 실손 보험 계산 이력 API
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/insurance/calculations")
+public class CalculationHistoryController {
+
+    private final CalculationHistoryService calculationHistoryService;
+
+    /**
+     * 실손 보험 계산 이력 목록 조회
+     */
+    @GetMapping
+    public ApiResponse<CalculationHistoryListResponse> getHistories(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PageableDefault(size = 20) Pageable pageable
+    ) {
+        Long userId = userDetails.getUserId();
+
+        log.info("실손 보험 계산 이력 목록 조회 요청 - userId={}, page={}, size={}",
+                userId,
+                pageable.getPageNumber(),
+                pageable.getPageSize()
+        );
+
+        return ApiResponse.success(calculationHistoryService.getHistories(userId, pageable));
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationHistoryController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationHistoryController.java
@@ -19,7 +19,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Slf4j
 @RestController
 @RequiredArgsConstructor
-@RequestMapping("/api/insurance/calculations")
+@RequestMapping("/api/calculations")
 public class CalculationHistoryController {
 
     private final CalculationHistoryService calculationHistoryService;

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/dto/CalculationHistoryListResponse.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/dto/CalculationHistoryListResponse.java
@@ -1,0 +1,64 @@
+package com.silsonfit.silsonfit_api.domain.calculation.dto;
+
+import com.silsonfit.silsonfit_api.domain.calculation.entity.CalculationHistory;
+import org.springframework.data.domain.Page;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+import java.util.List;
+
+/**
+ * 계산 이력 목록 응답
+ */
+public record CalculationHistoryListResponse(
+        List<CalculationSummary> calculations,
+        PageInfo pageInfo
+) {
+
+    public static CalculationHistoryListResponse from(Page<CalculationHistory> histories) {
+        return new CalculationHistoryListResponse(
+                histories.getContent().stream()
+                        .map(CalculationSummary::from)
+                        .toList(),
+                PageInfo.from(histories)
+        );
+    }
+
+    public record CalculationSummary(
+            String id,
+            OffsetDateTime calculatedDate,
+            String insuranceCoverage,
+            Integer medicalCost,
+            Integer refundAmount,
+            Boolean isCovered
+    ) {
+
+        public static CalculationSummary from(CalculationHistory history) {
+            return new CalculationSummary(
+                    "calc_" + history.getId(),
+                    history.getCreatedAt().atOffset(ZoneOffset.UTC),
+                    history.getTreatmentCategory().getDescription(),
+                    history.getMedicalCost(),
+                    history.getRefundAmount(),
+                    history.getIsCovered()
+            );
+        }
+    }
+
+    public record PageInfo(
+            int page,
+            int size,
+            int totalPages,
+            long totalElements
+    ) {
+
+        public static PageInfo from(Page<?> page) {
+            return new PageInfo(
+                    page.getNumber(),
+                    page.getSize(),
+                    page.getTotalPages(),
+                    page.getTotalElements()
+            );
+        }
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/repository/CalculationHistoryRepository.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/repository/CalculationHistoryRepository.java
@@ -1,10 +1,17 @@
 package com.silsonfit.silsonfit_api.domain.calculation.repository;
 
 import com.silsonfit.silsonfit_api.domain.calculation.entity.CalculationHistory;
+import org.springframework.data.domain.Page;
+import org.springframework.data.domain.Pageable;
 import org.springframework.data.jpa.repository.JpaRepository;
 
 /**
  * 실손 보험 계산 이력 Repository
  */
 public interface CalculationHistoryRepository extends JpaRepository<CalculationHistory, Long> {
+
+    /**
+     * 사용자별 계산 이력 최신순 조회
+     */
+    Page<CalculationHistory> findByUserIdOrderByCreatedAtDescIdDesc(Long userId, Pageable pageable);
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationHistoryService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationHistoryService.java
@@ -1,0 +1,28 @@
+package com.silsonfit.silsonfit_api.domain.calculation.service;
+
+import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationHistoryListResponse;
+import com.silsonfit.silsonfit_api.domain.calculation.repository.CalculationHistoryRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.domain.Pageable;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 실손 보험 계산 이력 Service
+ */
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CalculationHistoryService {
+
+    private final CalculationHistoryRepository calculationHistoryRepository;
+
+    /**
+     * 사용자별 계산 이력 목록 조회
+     */
+    public CalculationHistoryListResponse getHistories(Long userId, Pageable pageable) {
+        return CalculationHistoryListResponse.from(
+                calculationHistoryRepository.findByUserIdOrderByCreatedAtDescIdDesc(userId, pageable)
+        );
+    }
+}

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationHistoryControllerTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationHistoryControllerTest.java
@@ -49,7 +49,7 @@ class CalculationHistoryControllerTest {
         when(calculationHistoryService.getHistories(eq(1L), eq(PageRequest.of(0, 20))))
                 .thenReturn(response);
 
-        mockMvc.perform(get("/api/insurance/calculations")
+        mockMvc.perform(get("/api/calculations")
                         .param("page", "0")
                         .param("size", "20")
                         .with(user(new CustomUserDetails(1L))))

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationHistoryControllerTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationHistoryControllerTest.java
@@ -1,0 +1,72 @@
+package com.silsonfit.silsonfit_api.domain.calculation.controller;
+
+import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationHistoryListResponse;
+import com.silsonfit.silsonfit_api.domain.calculation.service.CalculationHistoryService;
+import com.silsonfit.silsonfit_api.global.auth.CustomUserDetails;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CalculationHistoryController.class)
+class CalculationHistoryControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    CalculationHistoryService calculationHistoryService;
+
+    @Test
+    @DisplayName("계산 이력 목록을 조회한다")
+    void getHistories_success() throws Exception {
+        CalculationHistoryListResponse response = new CalculationHistoryListResponse(
+                List.of(new CalculationHistoryListResponse.CalculationSummary(
+                        "calc_123",
+                        OffsetDateTime.parse("2024-06-01T10:00:00Z"),
+                        "MRI",
+                        3000000,
+                        2500000,
+                        true
+                )),
+                new CalculationHistoryListResponse.PageInfo(0, 20, 3, 45)
+        );
+
+        when(calculationHistoryService.getHistories(eq(1L), eq(PageRequest.of(0, 20))))
+                .thenReturn(response);
+
+        mockMvc.perform(get("/api/insurance/calculations")
+                        .param("page", "0")
+                        .param("size", "20")
+                        .with(user(new CustomUserDetails(1L))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"))
+                .andExpect(jsonPath("$.data.calculations[0].id").value("calc_123"))
+                .andExpect(jsonPath("$.data.calculations[0].calculatedDate").value("2024-06-01T10:00:00Z"))
+                .andExpect(jsonPath("$.data.calculations[0].insuranceCoverage").value("MRI"))
+                .andExpect(jsonPath("$.data.calculations[0].medicalCost").value(3000000))
+                .andExpect(jsonPath("$.data.calculations[0].refundAmount").value(2500000))
+                .andExpect(jsonPath("$.data.calculations[0].isCovered").value(true))
+                .andExpect(jsonPath("$.data.pageInfo.page").value(0))
+                .andExpect(jsonPath("$.data.pageInfo.size").value(20))
+                .andExpect(jsonPath("$.data.pageInfo.totalPages").value(3))
+                .andExpect(jsonPath("$.data.pageInfo.totalElements").value(45));
+
+        verify(calculationHistoryService).getHistories(eq(1L), eq(PageRequest.of(0, 20)));
+    }
+}

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationHistoryServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationHistoryServiceTest.java
@@ -1,0 +1,87 @@
+package com.silsonfit.silsonfit_api.domain.calculation.service;
+
+import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationHistoryListResponse;
+import com.silsonfit.silsonfit_api.domain.calculation.entity.CalculationHistory;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
+import com.silsonfit.silsonfit_api.domain.calculation.repository.CalculationHistoryRepository;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.domain.PageRequest;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@Transactional
+class CalculationHistoryServiceTest {
+
+    @Autowired
+    CalculationHistoryService calculationHistoryService;
+
+    @Autowired
+    CalculationHistoryRepository calculationHistoryRepository;
+
+    @Test
+    void 사용자_계산_이력만_최신순으로_조회한다() {
+        CalculationHistory firstHistory = calculationHistoryRepository.save(createHistory(
+                1L,
+                TreatmentCategory.MRI,
+                300000,
+                250000,
+                true
+        ));
+        CalculationHistory otherUserHistory = calculationHistoryRepository.save(createHistory(
+                2L,
+                TreatmentCategory.CT,
+                200000,
+                100000,
+                true
+        ));
+        CalculationHistory secondHistory = calculationHistoryRepository.save(createHistory(
+                1L,
+                TreatmentCategory.GENERAL_TREATMENT,
+                100000,
+                70000,
+                true
+        ));
+        calculationHistoryRepository.flush();
+
+        CalculationHistoryListResponse response = calculationHistoryService.getHistories(
+                1L,
+                PageRequest.of(0, 20)
+        );
+
+        assertThat(response.calculations()).hasSize(2);
+        assertThat(response.calculations().get(0).id()).isEqualTo("calc_" + secondHistory.getId());
+        assertThat(response.calculations().get(0).insuranceCoverage()).isEqualTo("일반진료");
+        assertThat(response.calculations().get(0).medicalCost()).isEqualTo(100000);
+        assertThat(response.calculations().get(0).refundAmount()).isEqualTo(70000);
+        assertThat(response.calculations().get(0).isCovered()).isTrue();
+        assertThat(response.calculations().get(1).id()).isEqualTo("calc_" + firstHistory.getId());
+        assertThat(response.calculations())
+                .noneSatisfy(calculation -> assertThat(calculation.id()).isEqualTo("calc_" + otherUserHistory.getId()));
+        assertThat(response.pageInfo().page()).isZero();
+        assertThat(response.pageInfo().size()).isEqualTo(20);
+        assertThat(response.pageInfo().totalElements()).isEqualTo(2);
+    }
+
+    private CalculationHistory createHistory(
+            Long userId,
+            TreatmentCategory treatmentCategory,
+            Integer medicalCost,
+            Integer refundAmount,
+            Boolean isCovered
+    ) {
+        return CalculationHistory.create(
+                userId,
+                1L,
+                medicalCost,
+                treatmentCategory,
+                null,
+                isCovered,
+                refundAmount,
+                medicalCost - refundAmount
+        );
+    }
+}


### PR DESCRIPTION
### 💻 작업 내용

* 보험 계산 이력 목록 조회 API 구현
* 계산 이력 조회 응답 DTO 추가
* 사용자 기준 이력 조회 로직 구현
* 관련 테스트 코드 작성

### ✨ 리뷰 포인트

* 목록 조회와 상세 조회의 응답 구조가 적절한지
* 사용자 본인의 계산 이력만 조회되도록 처리되었는지

### 📝 메모

* 이번 PR은 보험 계산 이력 조회 기능만 포함합니다.

### 🎯 관련 이슈

closed #47 