### PR TITLE
feat: 보험 즐겨찾기 API 구현

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationFavoriteController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationFavoriteController.java
@@ -1,0 +1,55 @@
+package com.silsonfit.silsonfit_api.domain.calculation.controller;
+
+import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationFavoriteResponse;
+import com.silsonfit.silsonfit_api.domain.calculation.service.CalculationFavoriteService;
+import com.silsonfit.silsonfit_api.global.auth.CustomUserDetails;
+import com.silsonfit.silsonfit_api.global.common.ApiResponse;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+/**
+ * 계산 이력 즐겨찾기 API
+ */
+@Slf4j
+@RestController
+@RequiredArgsConstructor
+@RequestMapping("/api/calculations")
+public class CalculationFavoriteController {
+
+    private final CalculationFavoriteService calculationFavoriteService;
+
+    /**
+     * 계산 이력 즐겨찾기 목록 조회
+     */
+    @GetMapping("/favorites")
+    public ApiResponse<List<CalculationFavoriteResponse>> getFavorites(
+            @AuthenticationPrincipal CustomUserDetails userDetails
+    ) {
+        Long userId = userDetails.getUserId();
+
+        log.info("계산 이력 즐겨찾기 목록 조회 요청 - userId={}", userId);
+
+        return ApiResponse.success(calculationFavoriteService.getFavorites(userId));
+    }
+
+    /**
+     * 계산 이력 즐겨찾기 토글
+     */
+    @PatchMapping("/{calculationHistoryId}/favorite")
+    public ApiResponse<Void> toggleFavorite(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long calculationHistoryId
+    ) {
+        Long userId = userDetails.getUserId();
+
+        log.info("계산 이력 즐겨찾기 토글 요청 - userId={}, calculationHistoryId={}", userId, calculationHistoryId);
+
+        calculationFavoriteService.toggleFavorite(userId, calculationHistoryId);
+
+        return ApiResponse.success();
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/dto/CalculationFavoriteResponse.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/dto/CalculationFavoriteResponse.java
@@ -1,0 +1,32 @@
+package com.silsonfit.silsonfit_api.domain.calculation.dto;
+
+import com.silsonfit.silsonfit_api.domain.calculation.entity.CalculationHistory;
+
+import java.time.OffsetDateTime;
+import java.time.ZoneOffset;
+
+/**
+ * 계산 이력 즐겨찾기 응답
+ */
+public record CalculationFavoriteResponse(
+        String id,
+        OffsetDateTime calculatedDate,
+        String insuranceCoverage,
+        Integer medicalCost,
+        Integer refundAmount,
+        Boolean isCovered,
+        Boolean isFavorite
+) {
+
+    public static CalculationFavoriteResponse from(CalculationHistory history) {
+        return new CalculationFavoriteResponse(
+                "calc_" + history.getId(),
+                history.getCreatedAt().atOffset(ZoneOffset.UTC),
+                history.getTreatmentCategory().getDescription(),
+                history.getMedicalCost(),
+                history.getRefundAmount(),
+                history.getIsCovered(),
+                history.getIsFavorite()
+        );
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/repository/CalculationHistoryRepository.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/repository/CalculationHistoryRepository.java
@@ -1,10 +1,26 @@
 package com.silsonfit.silsonfit_api.domain.calculation.repository;
 
 import com.silsonfit.silsonfit_api.domain.calculation.entity.CalculationHistory;
+import org.springframework.data.jpa.repository.Query;
 import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.data.repository.query.Param;
+
+import java.util.List;
 
 /**
  * 실손 보험 계산 이력 Repository
  */
 public interface CalculationHistoryRepository extends JpaRepository<CalculationHistory, Long> {
+
+    /**
+     * 사용자 계산 이력 즐겨찾기 목록 조회
+     */
+    @Query("""
+            select history
+            from CalculationHistory history
+            where history.userId = :userId
+              and history.isFavorite = true
+            order by history.createdAt desc, history.id desc
+            """)
+    List<CalculationHistory> findFavoritesByUserId(@Param("userId") Long userId);
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationFavoriteService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationFavoriteService.java
@@ -1,0 +1,55 @@
+package com.silsonfit.silsonfit_api.domain.calculation.service;
+
+import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationFavoriteResponse;
+import com.silsonfit.silsonfit_api.domain.calculation.entity.CalculationHistory;
+import com.silsonfit.silsonfit_api.domain.calculation.repository.CalculationHistoryRepository;
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.util.List;
+
+/**
+ * 계산 이력 즐겨찾기 Service
+ */
+@Slf4j
+@Service
+@RequiredArgsConstructor
+@Transactional(readOnly = true)
+public class CalculationFavoriteService {
+
+    private final CalculationHistoryRepository calculationHistoryRepository;
+
+    /**
+     * 계산 이력 즐겨찾기 목록 조회
+     */
+    public List<CalculationFavoriteResponse> getFavorites(Long userId) {
+        return calculationHistoryRepository.findFavoritesByUserId(userId).stream()
+                .map(CalculationFavoriteResponse::from)
+                .toList();
+    }
+
+    /**
+     * 계산 이력 즐겨찾기 토글
+     */
+    @Transactional
+    public void toggleFavorite(Long userId, Long calculationHistoryId) {
+        CalculationHistory history = getOwnedHistory(userId, calculationHistoryId);
+        history.toggleFavorite();
+    }
+
+    private CalculationHistory getOwnedHistory(Long userId, Long calculationHistoryId) {
+        CalculationHistory history = calculationHistoryRepository.findById(calculationHistoryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CALCULATION_HISTORY_NOT_FOUND));
+
+        if (!history.getUserId().equals(userId)) {
+            log.warn("계산 이력 접근 권한이 없습니다. - userId={}, calculationHistoryId={}", userId, calculationHistoryId);
+            throw new BusinessException(ErrorCode.CALCULATION_HISTORY_ACCESS_DENIED);
+        }
+
+        return history;
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
@@ -51,6 +51,8 @@ public enum ErrorCode {
     // ── Calculator ──
     COVERAGE_RULE_NOT_FOUND(404, "보장 룰을 찾을 수 없습니다."),
     EDI_CODE_NOT_FOUND(404, "EDI 코드를 찾을 수 없습니다."),
+    CALCULATION_HISTORY_NOT_FOUND(404, "계산 이력을 찾을 수 없습니다."),
+    CALCULATION_HISTORY_ACCESS_DENIED(403, "해당 계산 이력에 대한 접근 권한이 없습니다."),
 
     ;
 

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationFavoriteControllerTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationFavoriteControllerTest.java
@@ -1,0 +1,77 @@
+package com.silsonfit.silsonfit_api.domain.calculation.controller;
+
+import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationFavoriteResponse;
+import com.silsonfit.silsonfit_api.domain.calculation.service.CalculationFavoriteService;
+import com.silsonfit.silsonfit_api.global.auth.CustomUserDetails;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+import org.springframework.test.web.servlet.MockMvc;
+
+import java.time.OffsetDateTime;
+import java.util.List;
+
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(CalculationFavoriteController.class)
+class CalculationFavoriteControllerTest {
+
+    @Autowired
+    MockMvc mockMvc;
+
+    @MockitoBean
+    CalculationFavoriteService calculationFavoriteService;
+
+    @Test
+    @DisplayName("계산 이력 즐겨찾기를 토글한다")
+    void toggleFavorite_success() throws Exception {
+        mockMvc.perform(patch("/api/calculations/{calculationHistoryId}/favorite", 1L)
+                        .with(user(new CustomUserDetails(10L)))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"))
+                .andExpect(jsonPath("$.data").isEmpty());
+
+        verify(calculationFavoriteService).toggleFavorite(10L, 1L);
+    }
+
+    @Test
+    @DisplayName("계산 이력 즐겨찾기 목록을 조회한다")
+    void getFavorites_success() throws Exception {
+        when(calculationFavoriteService.getFavorites(10L)).thenReturn(List.of(
+                new CalculationFavoriteResponse(
+                        "calc_1",
+                        OffsetDateTime.parse("2026-05-04T10:00:00Z"),
+                        "MRI",
+                        100000,
+                        70000,
+                        true,
+                        true
+                )
+        ));
+
+        mockMvc.perform(get("/api/calculations/favorites")
+                        .with(user(new CustomUserDetails(10L))))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"))
+                .andExpect(jsonPath("$.data[0].id").value("calc_1"))
+                .andExpect(jsonPath("$.data[0].calculatedDate").value("2026-05-04T10:00:00Z"))
+                .andExpect(jsonPath("$.data[0].insuranceCoverage").value("MRI"))
+                .andExpect(jsonPath("$.data[0].medicalCost").value(100000))
+                .andExpect(jsonPath("$.data[0].refundAmount").value(70000))
+                .andExpect(jsonPath("$.data[0].isCovered").value(true))
+                .andExpect(jsonPath("$.data[0].isFavorite").value(true));
+    }
+
+}

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationFavoriteServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationFavoriteServiceTest.java
@@ -1,0 +1,113 @@
+package com.silsonfit.silsonfit_api.domain.calculation.service;
+
+import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationFavoriteResponse;
+import com.silsonfit.silsonfit_api.domain.calculation.entity.CalculationHistory;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
+import com.silsonfit.silsonfit_api.domain.calculation.repository.CalculationHistoryRepository;
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.BDDMockito.given;
+
+@ExtendWith(MockitoExtension.class)
+class CalculationFavoriteServiceTest {
+
+    @Mock
+    CalculationHistoryRepository calculationHistoryRepository;
+
+    @InjectMocks
+    CalculationFavoriteService calculationFavoriteService;
+
+    @Test
+    @DisplayName("계산 이력 즐겨찾기를 토글하여 등록한다")
+    void toggleFavorite_markFavorite() {
+        CalculationHistory history = createHistory(1L, 10L);
+        given(calculationHistoryRepository.findById(1L)).willReturn(Optional.of(history));
+
+        calculationFavoriteService.toggleFavorite(10L, 1L);
+
+        assertThat(history.getIsFavorite()).isTrue();
+    }
+
+    @Test
+    @DisplayName("다른 사용자의 계산 이력은 즐겨찾기 토글할 수 없다")
+    void toggleFavorite_accessDenied() {
+        CalculationHistory history = createHistory(1L, 99L);
+        given(calculationHistoryRepository.findById(1L)).willReturn(Optional.of(history));
+
+        assertThatThrownBy(() -> calculationFavoriteService.toggleFavorite(10L, 1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CALCULATION_HISTORY_ACCESS_DENIED);
+    }
+
+    @Test
+    @DisplayName("즐겨찾기한 계산 이력 목록을 조회한다")
+    void getFavorites_success() {
+        CalculationHistory history = createHistory(1L, 10L);
+        history.toggleFavorite();
+        given(calculationHistoryRepository.findFavoritesByUserId(10L)).willReturn(List.of(history));
+
+        List<CalculationFavoriteResponse> responses = calculationFavoriteService.getFavorites(10L);
+
+        assertThat(responses).hasSize(1);
+        assertThat(responses.get(0).id()).isEqualTo("calc_1");
+        assertThat(responses.get(0).insuranceCoverage()).isEqualTo("MRI");
+        assertThat(responses.get(0).medicalCost()).isEqualTo(100000);
+        assertThat(responses.get(0).refundAmount()).isEqualTo(70000);
+        assertThat(responses.get(0).isCovered()).isTrue();
+        assertThat(responses.get(0).isFavorite()).isTrue();
+    }
+
+    @Test
+    @DisplayName("계산 이력 즐겨찾기를 토글하여 해제한다")
+    void toggleFavorite_unmarkFavorite() {
+        CalculationHistory history = createHistory(1L, 10L);
+        history.toggleFavorite();
+        given(calculationHistoryRepository.findById(1L)).willReturn(Optional.of(history));
+
+        calculationFavoriteService.toggleFavorite(10L, 1L);
+
+        assertThat(history.getIsFavorite()).isFalse();
+    }
+
+    @Test
+    @DisplayName("존재하지 않는 계산 이력은 예외가 발생한다")
+    void favorite_historyNotFound() {
+        given(calculationHistoryRepository.findById(999L)).willReturn(Optional.empty());
+
+        assertThatThrownBy(() -> calculationFavoriteService.toggleFavorite(10L, 999L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CALCULATION_HISTORY_NOT_FOUND);
+    }
+
+    private CalculationHistory createHistory(Long historyId, Long userId) {
+        CalculationHistory history = CalculationHistory.create(
+                userId,
+                1L,
+                100000,
+                TreatmentCategory.MRI,
+                "MRI001",
+                true,
+                70000,
+                30000
+        );
+        ReflectionTestUtils.setField(history, "id", historyId);
+        ReflectionTestUtils.setField(history, "createdAt", LocalDateTime.of(2026, 5, 4, 10, 0));
+        return history;
+    }
+}


### PR DESCRIPTION
### 💻 작업 내용

* 보험 즐겨찾기 토글 API 구현
* 보험 즐겨찾기 목록 조회 API 구현
* 사용자 기준 즐겨찾기 관리 로직 구현
* 중복 등록 방지 로직 추가
* 관련 테스트 코드 작성

### ✨ 리뷰 포인트

* 즐겨찾기 중복 등록 방지 로직이 적절한지
* 사용자별 데이터 분리가 올바르게 처리되는지

### 📝 메모

* 즐겨찾기는 현재 상태에 따라 변경되는 토글 방식으로 구현했습니다.

### 🎯 관련 이슈

closed #49 