### PR TITLE
feat: 보험 계산 이력 삭제 API 구현

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationHistoryController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationHistoryController.java
@@ -9,7 +9,9 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.data.web.PageableDefault;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 
@@ -41,5 +43,22 @@ public class CalculationHistoryController {
         );
 
         return ApiResponse.success(calculationHistoryService.getHistories(userId, pageable));
+    }
+
+    /**
+     * 실손 보험 계산 이력 삭제
+     */
+    @DeleteMapping("/{calculationHistoryId}")
+    public ApiResponse<Void> deleteHistory(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
+            @PathVariable Long calculationHistoryId
+    ) {
+        Long userId = userDetails.getUserId();
+
+        log.info("실손 보험 계산 이력 삭제 요청 - userId={}, calculationHistoryId={}", userId, calculationHistoryId);
+
+        calculationHistoryService.deleteHistory(userId, calculationHistoryId);
+
+        return ApiResponse.success();
     }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/entity/CalculationHistory.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/entity/CalculationHistory.java
@@ -5,6 +5,8 @@ import com.silsonfit.silsonfit_api.global.common.BaseCreatedTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 
+import java.time.LocalDateTime;
+
 /**
  * 실손 보험 계산 이력 엔티티
  */
@@ -65,6 +67,15 @@ public class CalculationHistory extends BaseCreatedTimeEntity {
     @Builder.Default
     private Boolean isFavorite = false;
 
+    /** 삭제 여부 */
+    @Column(name = "is_deleted", nullable = false)
+    @Builder.Default
+    private Boolean isDeleted = false;
+
+    /** 삭제 일시 */
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt;
+
     public static CalculationHistory create(
             Long userId,
             Long insuranceId,
@@ -90,5 +101,12 @@ public class CalculationHistory extends BaseCreatedTimeEntity {
     /** 즐겨찾기 토글 */
     public void toggleFavorite() {
         this.isFavorite = !this.isFavorite;
+    }
+
+    /** 계산 이력 삭제 */
+    public void delete() {
+        this.isDeleted = true;
+        this.isFavorite = false;
+        this.deletedAt = LocalDateTime.now();
     }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/repository/CalculationHistoryRepository.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/repository/CalculationHistoryRepository.java
@@ -17,8 +17,11 @@ public interface CalculationHistoryRepository extends JpaRepository<CalculationH
     /**
      * 사용자별 계산 이력 최신순 조회
      */
-    Page<CalculationHistory> findByUserIdOrderByCreatedAtDescIdDesc(Long userId, Pageable pageable);
-
+    Page<CalculationHistory> findByUserIdAndIsDeletedFalseOrderByCreatedAtDescIdDesc(
+            Long userId,
+            Pageable pageable
+    );
+    
     /**
      * 사용자 계산 이력 즐겨찾기 목록 조회
      */
@@ -27,6 +30,7 @@ public interface CalculationHistoryRepository extends JpaRepository<CalculationH
             from CalculationHistory history
             where history.userId = :userId
               and history.isFavorite = true
+              and history.isDeleted = false
             order by history.createdAt desc, history.id desc
             """)
     List<CalculationHistory> findFavoritesByUserId(@Param("userId") Long userId);

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationHistoryService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationHistoryService.java
@@ -1,8 +1,12 @@
 package com.silsonfit.silsonfit_api.domain.calculation.service;
 
 import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationHistoryListResponse;
+import com.silsonfit.silsonfit_api.domain.calculation.entity.CalculationHistory;
 import com.silsonfit.silsonfit_api.domain.calculation.repository.CalculationHistoryRepository;
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -13,6 +17,7 @@ import org.springframework.transaction.annotation.Transactional;
 @Service
 @RequiredArgsConstructor
 @Transactional(readOnly = true)
+@Slf4j
 public class CalculationHistoryService {
 
     private final CalculationHistoryRepository calculationHistoryRepository;
@@ -22,7 +27,23 @@ public class CalculationHistoryService {
      */
     public CalculationHistoryListResponse getHistories(Long userId, Pageable pageable) {
         return CalculationHistoryListResponse.from(
-                calculationHistoryRepository.findByUserIdOrderByCreatedAtDescIdDesc(userId, pageable)
+                calculationHistoryRepository.findByUserIdAndIsDeletedFalseOrderByCreatedAtDescIdDesc(userId, pageable)
         );
+    }
+
+    /**
+     * 사용자 계산 이력 삭제
+     */
+    @Transactional
+    public void deleteHistory(Long userId, Long calculationHistoryId) {
+        CalculationHistory history = calculationHistoryRepository.findById(calculationHistoryId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.CALCULATION_HISTORY_NOT_FOUND));
+
+        if (!history.getUserId().equals(userId)) {
+            log.warn("계산 이력 삭제 권한이 없습니다. - userId={}, calculationHistoryId={}", userId, calculationHistoryId);
+            throw new BusinessException(ErrorCode.CALCULATION_HISTORY_ACCESS_DENIED);
+        }
+
+        history.delete();
     }
 }

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationHistoryControllerTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationHistoryControllerTest.java
@@ -18,6 +18,8 @@ import static org.mockito.ArgumentMatchers.eq;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.user;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.delete;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
@@ -68,5 +70,19 @@ class CalculationHistoryControllerTest {
                 .andExpect(jsonPath("$.data.pageInfo.totalElements").value(45));
 
         verify(calculationHistoryService).getHistories(eq(1L), eq(PageRequest.of(0, 20)));
+    }
+
+    @Test
+    @DisplayName("계산 이력을 삭제한다")
+    void deleteHistory_success() throws Exception {
+        mockMvc.perform(delete("/api/calculations/{calculationHistoryId}", 1L)
+                        .with(user(new CustomUserDetails(1L)))
+                        .with(csrf()))
+                .andExpect(status().isOk())
+                .andExpect(jsonPath("$.code").value(200))
+                .andExpect(jsonPath("$.message").value("success"))
+                .andExpect(jsonPath("$.data").isEmpty());
+
+        verify(calculationHistoryService).deleteHistory(1L, 1L);
     }
 }

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationHistoryServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationHistoryServiceTest.java
@@ -4,6 +4,8 @@ import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationHistoryList
 import com.silsonfit.silsonfit_api.domain.calculation.entity.CalculationHistory;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
 import com.silsonfit.silsonfit_api.domain.calculation.repository.CalculationHistoryRepository;
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -11,6 +13,7 @@ import org.springframework.data.domain.PageRequest;
 import org.springframework.transaction.annotation.Transactional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 @Transactional
@@ -45,6 +48,14 @@ class CalculationHistoryServiceTest {
                 70000,
                 true
         ));
+        CalculationHistory deletedHistory = calculationHistoryRepository.save(createHistory(
+                1L,
+                TreatmentCategory.CT,
+                500000,
+                300000,
+                true
+        ));
+        deletedHistory.delete();
         calculationHistoryRepository.flush();
 
         CalculationHistoryListResponse response = calculationHistoryService.getHistories(
@@ -61,9 +72,47 @@ class CalculationHistoryServiceTest {
         assertThat(response.calculations().get(1).id()).isEqualTo("calc_" + firstHistory.getId());
         assertThat(response.calculations())
                 .noneSatisfy(calculation -> assertThat(calculation.id()).isEqualTo("calc_" + otherUserHistory.getId()));
+        assertThat(response.calculations())
+                .noneSatisfy(calculation -> assertThat(calculation.id()).isEqualTo("calc_" + deletedHistory.getId()));
         assertThat(response.pageInfo().page()).isZero();
         assertThat(response.pageInfo().size()).isEqualTo(20);
         assertThat(response.pageInfo().totalElements()).isEqualTo(2);
+    }
+
+    @Test
+    void 사용자_계산_이력을_soft_delete한다() {
+        CalculationHistory history = calculationHistoryRepository.save(createHistory(
+                1L,
+                TreatmentCategory.MRI,
+                300000,
+                250000,
+                true
+        ));
+        history.toggleFavorite();
+        calculationHistoryRepository.flush();
+
+        calculationHistoryService.deleteHistory(1L, history.getId());
+
+        assertThat(history.getIsDeleted()).isTrue();
+        assertThat(history.getIsFavorite()).isFalse();
+        assertThat(history.getDeletedAt()).isNotNull();
+    }
+
+    @Test
+    void 다른_사용자의_계산_이력은_삭제할_수_없다() {
+        CalculationHistory history = calculationHistoryRepository.save(createHistory(
+                2L,
+                TreatmentCategory.MRI,
+                300000,
+                250000,
+                true
+        ));
+        calculationHistoryRepository.flush();
+
+        assertThatThrownBy(() -> calculationHistoryService.deleteHistory(1L, history.getId()))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.CALCULATION_HISTORY_ACCESS_DENIED);
     }
 
     private CalculationHistory createHistory(


### PR DESCRIPTION
### 💻 작업 내용

* 보험 계산 이력 삭제 API 구현
* soft delete 기반으로 구현 후, 관련 조회 기능 주성
* 사용자 본인의 계산 이력만 삭제 가능하도록 검증 로직 추가
* 존재하지 않는 계산 이력에 대한 예외 처리 추가

### ✨ 리뷰 포인트

* 삭제 요청 시 사용자 권한 검증이 적절한지
* 존재하지 않는 이력 조회 시 예외 처리가 자연스러운지
* 삭제 시 즐겨찾기는 해제하는게 적절한지 

### 📝 메모

* 계산 이력은 분석, 검증, CS 대응 등에 활용 가능한 데이터이므로 물리 삭제 대신 soft delete로 구현했습니다.

### 🎯 관련 이슈

closed #53 