### PR TITLE
feat: 회원 탈퇴 API

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/controller/AuthController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/controller/AuthController.java
@@ -13,6 +13,7 @@ import com.silsonfit.silsonfit_api.global.common.ApiResponse;
 import jakarta.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.web.bind.annotation.DeleteMapping;
 import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestBody;
 import org.springframework.web.bind.annotation.RequestMapping;
@@ -21,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 /**
  * 인증 관련 API
  *
- * 카카오 로그인, 토큰 재발급, 약관 동의, 로그아웃 제공
+ * 카카오 로그인, 토큰 재발급, 약관 동의, 로그아웃, 회원 탈퇴 제공
  */
 @RestController
 @RequestMapping("/api/auth")
@@ -69,5 +70,15 @@ public class AuthController {
             @Valid @RequestBody LogoutRequest request) {
         authService.logout(request.refreshToken());
         return ApiResponse.success(new LogoutResponse(true));
+    }
+
+    /**
+     * 회원 탈퇴 (30일 유예, 재로그인 시 복구)
+     */
+    @DeleteMapping("/withdraw")
+    public ApiResponse<Void> withdraw(
+            @AuthenticationPrincipal CustomUserDetails userDetails) {
+        authService.withdraw(userDetails.getUserId());
+        return ApiResponse.success();
     }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/scheduler/WithdrawCleanupScheduler.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/scheduler/WithdrawCleanupScheduler.java
@@ -1,0 +1,68 @@
+package com.silsonfit.silsonfit_api.domain.auth.scheduler;
+
+import com.silsonfit.silsonfit_api.domain.auth.repository.RefreshTokenRepository;
+import com.silsonfit.silsonfit_api.domain.auth.service.AuthService;
+import com.silsonfit.silsonfit_api.domain.user.entity.User;
+import com.silsonfit.silsonfit_api.domain.user.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.EnableScheduling;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+/**
+ * 탈퇴 유예 만료 사용자 정리 스케줄러
+ *
+ * 매일 자정에 실행하여 탈퇴 후 30일 경과한 사용자의 데이터를 삭제한다.
+ */
+@Slf4j
+@Component
+@EnableScheduling
+@RequiredArgsConstructor
+public class WithdrawCleanupScheduler {
+
+    private final UserRepository userRepository;
+    private final RefreshTokenRepository refreshTokenRepository;
+    // TODO: 각 도메인 삭제 서비스 주입
+    // private final AnalysisHistoryService analysisHistoryService;  // 분석 도메인 (C 담당)
+    // private final CalcHistoryService calcHistoryService;          // 계산 도메인 (C 담당)
+    // private final UserInsuranceRepository userInsuranceRepository; // 보험 도메인 (내 담당)
+
+    /**
+     * 매일 자정에 탈퇴 유예 만료 사용자 정리
+     */
+    @Scheduled(cron = "0 0 0 * * *")
+    @Transactional
+    public void cleanupExpiredUsers() {
+        LocalDateTime expiredBefore = LocalDateTime.now().minusDays(AuthService.WITHDRAW_GRACE_DAYS);
+        List<User> expiredUsers = userRepository.findByDeactivatedAtNotNullAndDeactivatedAtBefore(expiredBefore);
+
+        if (expiredUsers.isEmpty()) {
+            return;
+        }
+
+        log.info("탈퇴 유예 만료 사용자 {}명 삭제 시작", expiredUsers.size());
+
+        for (User user : expiredUsers) {
+            // TODO: 각 도메인 데이터 삭제 (메서드 준비되면 연결)
+            // analysisHistoryService.deleteByUserId(user.getId());  // 분석 도메인
+            // calcHistoryService.deleteByUserId(user.getId());      // 계산 도메인
+            // userInsuranceRepository.deleteByUserId(user.getId()); // 보험 도메인
+
+            // Auth 도메인 데이터 삭제
+            refreshTokenRepository.findByUser(user)
+                    .ifPresent(refreshTokenRepository::delete);
+
+            // 사용자 삭제
+            userRepository.delete(user);
+
+            log.info("사용자 삭제 완료: userId={}", user.getId());
+        }
+
+        log.info("탈퇴 유예 만료 사용자 {}명 삭제 완료", expiredUsers.size());
+    }
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/scheduler/WithdrawCleanupScheduler.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/scheduler/WithdrawCleanupScheduler.java
@@ -2,6 +2,7 @@ package com.silsonfit.silsonfit_api.domain.auth.scheduler;
 
 import com.silsonfit.silsonfit_api.domain.auth.repository.RefreshTokenRepository;
 import com.silsonfit.silsonfit_api.domain.auth.service.AuthService;
+import com.silsonfit.silsonfit_api.domain.insurance.repository.UserInsuranceRepository;
 import com.silsonfit.silsonfit_api.domain.user.entity.User;
 import com.silsonfit.silsonfit_api.domain.user.repository.UserRepository;
 import lombok.RequiredArgsConstructor;
@@ -27,10 +28,7 @@ public class WithdrawCleanupScheduler {
 
     private final UserRepository userRepository;
     private final RefreshTokenRepository refreshTokenRepository;
-    // TODO: 각 도메인 삭제 서비스 주입
-    // private final AnalysisHistoryService analysisHistoryService;  // 분석 도메인 (C 담당)
-    // private final CalcHistoryService calcHistoryService;          // 계산 도메인 (C 담당)
-    // private final UserInsuranceRepository userInsuranceRepository; // 보험 도메인 (내 담당)
+    private final UserInsuranceRepository userInsuranceRepository;
 
     /**
      * 매일 자정에 탈퇴 유예 만료 사용자 정리
@@ -48,12 +46,10 @@ public class WithdrawCleanupScheduler {
         log.info("탈퇴 유예 만료 사용자 {}명 삭제 시작", expiredUsers.size());
 
         for (User user : expiredUsers) {
-            // TODO: 각 도메인 데이터 삭제 (메서드 준비되면 연결)
-            // analysisHistoryService.deleteByUserId(user.getId());  // 분석 도메인
-            // calcHistoryService.deleteByUserId(user.getId());      // 계산 도메인
-            // userInsuranceRepository.deleteByUserId(user.getId()); // 보험 도메인
+            // 등록 보험 삭제
+            userInsuranceRepository.deleteAllByUserId(user.getId());
 
-            // Auth 도메인 데이터 삭제
+            // Refresh Token 삭제
             refreshTokenRepository.findByUser(user)
                     .ifPresent(refreshTokenRepository::delete);
 

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/service/AuthService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/auth/service/AuthService.java
@@ -23,11 +23,13 @@ import java.util.Optional;
 /**
  * 인증 관련 비즈니스 로직
  *
- * 카카오 로그인, 토큰 재발급, 약관 동의, 로그아웃 처리
+ * 카카오 로그인, 토큰 재발급, 약관 동의, 로그아웃, 회원 탈퇴 처리
  */
 @Service
 @RequiredArgsConstructor
 public class AuthService {
+
+    public static final long WITHDRAW_GRACE_DAYS = 30;
 
     private final KakaoClient kakaoClient;
     private final UserRepository userRepository;
@@ -57,6 +59,14 @@ public class AuthService {
                         .profileImageUrl(kakaoUser.profileImageUrl())
                         .build()
         ));
+
+        // 2-1) 탈퇴 유예 사용자 복구 처리
+        if (user.isDeactivated()) {
+            if (user.getDeactivatedAt().plusDays(WITHDRAW_GRACE_DAYS).isBefore(LocalDateTime.now())) {
+                throw new BusinessException(ErrorCode.WITHDRAW_GRACE_PERIOD_EXPIRED);
+            }
+            user.reactivate();
+        }
 
         // 3) 토큰 발급 및 Refresh Token 저장/갱신
         String accessToken = jwtTokenProvider.createAccessToken(user.getId());
@@ -125,6 +135,29 @@ public class AuthService {
                 .orElseThrow(() -> new BusinessException(ErrorCode.INVALID_REFRESH_TOKEN));
 
         refreshTokenRepository.delete(token);
+    }
+
+    /**
+     * 회원 탈퇴 처리
+     *
+     * 계정을 즉시 비활성화하고 Refresh Token을 삭제한다.
+     * 30일 내 재로그인 시 복구 가능, 30일 경과 시 스케줄러가 데이터 삭제
+     */
+    @Transactional
+    public void withdraw(Long userId) {
+        User user = userRepository.findById(userId)
+                .orElseThrow(() -> new BusinessException(ErrorCode.USER_NOT_FOUND));
+
+        if (user.isDeactivated()) {
+            throw new BusinessException(ErrorCode.DEACTIVATED_USER);
+        }
+
+        // 계정 비활성화
+        user.deactivate();
+
+        // Refresh Token 삭제
+        refreshTokenRepository.findByUser(user)
+                .ifPresent(refreshTokenRepository::delete);
     }
 
     /**

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/repository/UserInsuranceRepository.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/insurance/repository/UserInsuranceRepository.java
@@ -27,4 +27,9 @@ public interface UserInsuranceRepository extends JpaRepository<UserInsurance, Lo
      * 사용자의 동일 보험 상품 등록 여부 확인
      */
     boolean existsByUserIdAndInsuranceId(Long userId, Long insuranceId);
+
+    /**
+     * 사용자의 등록 보험 전체 삭제 (회원 탈퇴 시)
+     */
+    void deleteAllByUserId(Long userId);
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/entity/User.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/entity/User.java
@@ -44,6 +44,10 @@ public class User extends BaseTimeEntity {
     @Column
     private LocalDateTime termsAgreedAt;
 
+    // 탈퇴 요청 시각 (null이면 활성, non-null이면 탈퇴 유예 중)
+    @Column
+    private LocalDateTime deactivatedAt;
+
     @Builder
     public User(Long socialId, String name, String email, String profileImageUrl) {
         this.socialId = socialId;
@@ -64,5 +68,26 @@ public class User extends BaseTimeEntity {
      */
     public void updateName(String name) {
         this.name = name;
+    }
+
+    /**
+     * 회원 탈퇴 처리 (비활성화)
+     */
+    public void deactivate() {
+        this.deactivatedAt = LocalDateTime.now();
+    }
+
+    /**
+     * 탈퇴 유예 사용자 복구
+     */
+    public void reactivate() {
+        this.deactivatedAt = null;
+    }
+
+    /**
+     * 탈퇴 상태 여부 확인
+     */
+    public boolean isDeactivated() {
+        return this.deactivatedAt != null;
     }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/repository/UserRepository.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/user/repository/UserRepository.java
@@ -3,6 +3,8 @@ package com.silsonfit.silsonfit_api.domain.user.repository;
 import com.silsonfit.silsonfit_api.domain.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.time.LocalDateTime;
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -14,4 +16,9 @@ public interface UserRepository extends JpaRepository<User, Long> {
      * 카카오 소셜 ID로 사용자 조회
      */
     Optional<User> findBySocialId(Long socialId);
+
+    /**
+     * 탈퇴 유예 만료 사용자 조회 (deactivatedAt이 지정 시각 이전인 사용자)
+     */
+    List<User> findByDeactivatedAtNotNullAndDeactivatedAtBefore(LocalDateTime dateTime);
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/error/ErrorCode.java
@@ -29,6 +29,7 @@ public enum ErrorCode {
     // ── User ──
     USER_NOT_FOUND(404, "사용자를 찾을 수 없습니다."),
     DEACTIVATED_USER(403, "탈퇴한 사용자입니다."),
+    WITHDRAW_GRACE_PERIOD_EXPIRED(403, "탈퇴 후 30일이 경과하여 복구할 수 없습니다."),
     INVALID_NICKNAME(400, "사용할 수 없는 닉네임입니다."),
 
     // ── Analysis ──

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/auth/service/AuthServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/auth/service/AuthServiceTest.java
@@ -265,6 +265,91 @@ class AuthServiceTest {
                 .isEqualTo(ErrorCode.INVALID_REFRESH_TOKEN);
     }
 
+    // ──────────── withdraw ────────────
+
+    @Test
+    @DisplayName("회원 탈퇴 성공 시 계정이 비활성화되고 Refresh Token이 삭제된다")
+    void withdraw_success() {
+        // given
+        User user = userWithId(1L, 111L);
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        RefreshToken stored = RefreshToken.builder()
+                .user(user)
+                .token("refresh")
+                .expiresAt(LocalDateTime.now().plusDays(7))
+                .build();
+        given(refreshTokenRepository.findByUser(user)).willReturn(Optional.of(stored));
+
+        // when
+        authService.withdraw(1L);
+
+        // then
+        assertThat(user.isDeactivated()).isTrue();
+        assertThat(user.getDeactivatedAt()).isNotNull();
+        verify(refreshTokenRepository).delete(stored);
+    }
+
+    @Test
+    @DisplayName("이미 탈퇴한 사용자가 다시 탈퇴 요청 시 DEACTIVATED_USER 예외")
+    void withdraw_alreadyDeactivated() {
+        // given
+        User user = userWithId(1L, 111L);
+        user.deactivate();
+        given(userRepository.findById(1L)).willReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> authService.withdraw(1L))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.DEACTIVATED_USER);
+    }
+
+    @Test
+    @DisplayName("탈퇴 유예 사용자가 30일 내 재로그인 시 계정이 복구된다")
+    void login_reactivateWithinGracePeriod() {
+        // given
+        User user = userWithId(1L, 444L);
+        user.deactivate(); // 방금 탈퇴
+
+        given(kakaoClient.getUserInfo("kakao-access")).willReturn(
+                new KakaoClient.KakaoUserInfo(444L, "홍길동", null, null));
+        given(userRepository.findBySocialId(444L)).willReturn(Optional.of(user));
+        given(jwtTokenProvider.createAccessToken(1L)).willReturn("access-token");
+        given(jwtTokenProvider.createRefreshToken()).willReturn("refresh-token");
+        given(jwtTokenProvider.getRefreshTokenExpiration()).willReturn(REFRESH_TTL_MS);
+        given(refreshTokenRepository.findByUser(user)).willReturn(Optional.empty());
+
+        // when
+        LoginResponse response = authService.login(new LoginRequest("kakao-access"));
+
+        // then
+        assertThat(user.isDeactivated()).isFalse();
+        assertThat(user.getDeactivatedAt()).isNull();
+        assertThat(response.accessToken()).isEqualTo("access-token");
+    }
+
+    @Test
+    @DisplayName("탈퇴 후 30일 경과한 사용자가 재로그인 시 WITHDRAW_GRACE_PERIOD_EXPIRED 예외")
+    void login_gracePeriodExpired() {
+        // given
+        User user = userWithId(1L, 555L);
+        user.deactivate();
+        // 31일 전으로 설정
+        ReflectionTestUtils.setField(user, "deactivatedAt",
+                LocalDateTime.now().minusDays(31));
+
+        given(kakaoClient.getUserInfo("kakao-access")).willReturn(
+                new KakaoClient.KakaoUserInfo(555L, "홍길동", null, null));
+        given(userRepository.findBySocialId(555L)).willReturn(Optional.of(user));
+
+        // when & then
+        assertThatThrownBy(() -> authService.login(new LoginRequest("kakao-access")))
+                .isInstanceOf(BusinessException.class)
+                .extracting(e -> ((BusinessException) e).getErrorCode())
+                .isEqualTo(ErrorCode.WITHDRAW_GRACE_PERIOD_EXPIRED);
+    }
+
     // ──────────── helper ────────────
 
     private User userWithId(Long id, Long socialId) {


### PR DESCRIPTION
<!-- PR의 타입은 Label을 통해 나타내주세요. -->

### 💻 작업 내용
<!-- 진행한 작업 내용에 대해 작성해주세요. -->
- 회원 탈퇴 API 구현 (30일 유예, 재로그인 시 복구)
- User 엔티티에 탈퇴 관련 필드 추가
- 로그인 시 탈퇴 유예 사용자 복구 로직 추가
- 탈퇴 유예 만료 사용자 정리 스케줄러 구현(매일 자정)
- 탈퇴 시 등록 보험 삭제

### ✨ 리뷰 포인트
<!-- (ex) query 가 너무 복잡한 것 같은데 이 위주로 봐주세요. -->
- 탈퇴 → 30일 유예 → 복구/삭제 플로우의 흐름
- JWT 필터 차단은 Access Token 자연 만료 방식으로 처리 (Refresh Token 삭제로 재발급 차단)

### 📝 메모
<!-- PR 관련 전달사항이 있다면 이곳에 작성해주세요. -->
- 탈퇴 사용자의 분석/계산 이력은 현재 삭제하지 않습니다.
- 등록 보험은 사용자 없이 의미 없는 데이터라 스케줄러에서 함께 삭제합니다.

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
closed #27 
