### PR TITLE
feat(swagger): SwaggerConfig 추가

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/SwaggerConfig.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/SwaggerConfig.java
@@ -1,0 +1,33 @@
+package com.silsonfit.silsonfit_api.global.config;
+
+import io.swagger.v3.oas.models.Components;
+import io.swagger.v3.oas.models.OpenAPI;
+import io.swagger.v3.oas.models.info.Info;
+import io.swagger.v3.oas.models.security.SecurityRequirement;
+import io.swagger.v3.oas.models.security.SecurityScheme;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class SwaggerConfig {
+
+    private static final String JWT_SECURITY_SCHEME_NAME = "bearerAuth";
+
+    @Bean
+    public OpenAPI openAPI() {
+        SecurityScheme jwtSecurityScheme = new SecurityScheme()
+                .name(JWT_SECURITY_SCHEME_NAME)
+                .type(SecurityScheme.Type.HTTP)
+                .scheme("bearer")
+                .bearerFormat("JWT");
+
+        return new OpenAPI()
+                .info(new Info()
+                        .title("Silsonfit API")
+                        .version("v1"))
+                .components(new Components()
+                        .addSecuritySchemes(JWT_SECURITY_SCHEME_NAME, jwtSecurityScheme))
+                .addSecurityItem(new SecurityRequirement()
+                        .addList(JWT_SECURITY_SCHEME_NAME));
+    }
+}


### PR DESCRIPTION
### 💻 작업 내용
- SwaggerConfig를 추가하여 Swagger UI에서 JWT 토큰 인증 설정을 사용할 수 있도록 구성했습니다.

### ✨ 리뷰 포인트
- Swagger UI에서 Authorize 버튼을 통해 JWT 토큰 입력 후 인증이 필요한 API를 호출할 수 있는지 확인 부탁드립니다.

### 📝 메모
- API 테스트 편의성을 위해 Swagger 문서에서 Bearer 토큰 인증 방식을 설정했습니다.

### 🎯 관련 이슈
closed #62