### PR TITLE
feat: 분석 이력 삭제 정책 변경

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/entity/AnalysisHistory.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/entity/AnalysisHistory.java
@@ -6,16 +6,23 @@ import com.silsonfit.silsonfit_api.global.common.BaseCreatedTimeEntity;
 import jakarta.persistence.*;
 import lombok.*;
 import org.hibernate.annotations.JdbcTypeCode;
+import org.hibernate.annotations.SQLDelete;
+import org.hibernate.annotations.SQLRestriction;
 import org.hibernate.type.SqlTypes;
+
+import java.time.LocalDateTime;
 
 /**
  * AI의 약관 분석 결과 이력을 저장하는 엔티티
  */
 @Entity
+@Table(name = "analysis_history")
 @Getter
 @Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
+@SQLDelete(sql = "update analysis_history set is_deleted = true, deleted_at = NOW() where id = ?")
+@SQLRestriction(value = "is_deleted = false")
 public class AnalysisHistory extends BaseCreatedTimeEntity {
 
     @Id
@@ -62,6 +69,13 @@ public class AnalysisHistory extends BaseCreatedTimeEntity {
     @Column(name = "is_favorite", nullable = false)
     @Builder.Default
     private Boolean isFavorite = false; // 즐겨찾기
+
+    @Column(name = "is_delete", nullable = false)
+    @Builder.Default
+    private Boolean isDelete = false; // 삭제 여부
+
+    @Column(name = "deleted_at")
+    private LocalDateTime deletedAt; // 삭제 일자
 
     // 생성자 - 정적 팩토리 메서드 패턴 + 빌더 사용
     public static AnalysisHistory create(AnalysisHistoryCreateCommand command) {

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/entity/AnalysisHistory.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/entity/AnalysisHistory.java
@@ -21,7 +21,7 @@ import java.time.LocalDateTime;
 @Builder(access = AccessLevel.PRIVATE)
 @AllArgsConstructor(access = AccessLevel.PROTECTED)
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
-@SQLDelete(sql = "update analysis_history set is_deleted = true, deleted_at = NOW() where id = ?")
+@SQLDelete(sql = "update analysis_history set is_deleted = true, deleted_at = CURRENT_TIMESTAMP where analysis_history_id = ?")
 @SQLRestriction(value = "is_deleted = false")
 public class AnalysisHistory extends BaseCreatedTimeEntity {
 

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/entity/AnalysisHistory.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/entity/AnalysisHistory.java
@@ -70,9 +70,9 @@ public class AnalysisHistory extends BaseCreatedTimeEntity {
     @Builder.Default
     private Boolean isFavorite = false; // 즐겨찾기
 
-    @Column(name = "is_delete", nullable = false)
+    @Column(name = "is_deleted", nullable = false)
     @Builder.Default
-    private Boolean isDelete = false; // 삭제 여부
+    private Boolean isDeleted = false; // 삭제 여부
 
     @Column(name = "deleted_at")
     private LocalDateTime deletedAt; // 삭제 일자

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/service/AnalysisHistoryService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/analysis/service/AnalysisHistoryService.java
@@ -4,7 +4,6 @@ import com.silsonfit.silsonfit_api.domain.analysis.dto.AnalysisHistoryDetailResp
 import com.silsonfit.silsonfit_api.domain.analysis.dto.AnalysisHistoryListResponse;
 import com.silsonfit.silsonfit_api.domain.analysis.entity.AnalysisHistory;
 import com.silsonfit.silsonfit_api.domain.analysis.repository.AnalysisHistoryRepository;
-import com.silsonfit.silsonfit_api.global.aws.S3Service;
 import com.silsonfit.silsonfit_api.global.error.BusinessException;
 import com.silsonfit.silsonfit_api.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -21,7 +20,6 @@ import org.springframework.transaction.annotation.Transactional;
 public class AnalysisHistoryService {
 
     private final AnalysisHistoryRepository analysisHistoryRepository;
-    private final S3Service s3Service;
 
     /**
      * 분석 이력 리스트 조회
@@ -69,8 +67,6 @@ public class AnalysisHistoryService {
             log.warn("이력 삭제 권한이 없습니다. - userId={}, historyId={}", userId, historyId);
             throw new BusinessException(ErrorCode.HISTORY_ACCESS_DENIED);
         }
-
-        s3Service.delete(history.getPdfFileUrl());
 
         analysisHistoryRepository.delete(history);
     }

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/analysis/service/AnalysisHistoryServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/analysis/service/AnalysisHistoryServiceTest.java
@@ -5,6 +5,7 @@ import com.silsonfit.silsonfit_api.domain.analysis.dto.AnalysisHistoryListRespon
 import com.silsonfit.silsonfit_api.domain.analysis.entity.AnalysisHistory;
 import com.silsonfit.silsonfit_api.domain.analysis.repository.AnalysisHistoryRepository;
 import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import jakarta.persistence.EntityManager;
 import org.junit.jupiter.api.*;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -23,6 +24,8 @@ class AnalysisHistoryServiceTest {
     AnalysisHistoryService analysisHistoryService;
     @Autowired
     AnalysisHistoryRepository analysisHistoryRepository;
+    @Autowired
+    EntityManager em; // 네이티브 쿼리로 DB 상태 확인을 위해 추가
 
     AnalysisHistory dummy1;
     AnalysisHistory dummy2;
@@ -49,14 +52,6 @@ class AnalysisHistoryServiceTest {
     }
 
     @Test
-    void 분석이력_삭제_테스트() {
-        analysisHistoryService.deleteHistory(1L, dummy2.getId());
-
-        assertThat(analysisHistoryRepository.findById(dummy2.getId()).isPresent())
-                .isFalse();
-    }
-
-    @Test
     void 다른유저가_다른이력을_조회하려고하면_예외발생() {
         assertThatThrownBy(() -> {
             analysisHistoryService.getHistoryDetail(2L, dummy1.getId());
@@ -70,6 +65,30 @@ class AnalysisHistoryServiceTest {
             analysisHistoryService.deleteHistory(2L,dummy1.getId());
         }).isInstanceOf(BusinessException.class)
                 .hasMessageContaining("해당 분석 이력에 대한 접근 권한이 없습니다.");
+    }
+
+    @Test
+    void 분석이력_소프트삭제_테스트() {
+        Long userId = 1L;
+        Long historyId = dummy2.getId();
+
+        analysisHistoryService.deleteHistory(userId, historyId);
+
+        // 영속성 컨텍스트를 비워야 다음 조회 시 DB에 쿼리를 날린다.
+        em.flush();
+        em.clear();
+
+        // DB 에는 있지만 @SQLRestriction 애노테이션 때문에 조회가 안되어야한다.
+        assertThat(analysisHistoryRepository.findById(historyId))
+                .isEmpty();
+
+        // DB 에는 있기 때문에 직접 쿼리문을 날려 is_deleted 가 true 인지 확인
+        Boolean isDeleted = (Boolean) em.createNativeQuery(
+                        "select is_deleted from analysis_history where analysis_history_id = :id")
+                .setParameter("id", historyId)
+                .getSingleResult();
+
+        assertThat(isDeleted).isTrue();
     }
 
 }


### PR DESCRIPTION
<!-- PR의 타입은 Label을 통해 나타내주세요. -->

### 💻 작업 내용
<!-- 진행한 작업 내용에 대해 작성해주세요. -->
- AnalysisHistory 엔티티에 is_deleted, deleted_at 필드 추가, @SQLDelete, @SQLRestriction 애노테이션 추가
- 삭제 정책이 소프트 삭제로 변경됨 -> S3 삭제 로직 제거
- 소프트 삭제 관련 테스트 코드 작성 

### ✨ 리뷰 포인트
<!-- (ex) query 가 너무 복잡한 것 같은데 이 위주로 봐주세요. -->

### 📝 메모
<!-- PR 관련 전달사항이 있다면 이곳에 작성해주세요. -->

### 🎯 관련 이슈
<!-- pr이 merge 되면 이슈가 자동으로 close 되도록 합니다. 만약 자동 close 를 하지 않고 이슈만 링크한다면 closed 키워드를 삭제해주세요.-->
closed #56 
