### PR TITLE
[Refactor] 환급금 계산 API 변경

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/dto/CalculationRequest.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/dto/CalculationRequest.java
@@ -1,8 +1,11 @@
 package com.silsonfit.silsonfit_api.domain.calculation.dto;
 
+import com.silsonfit.silsonfit_api.domain.calculation.enums.HospitalType;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.PayType;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.PurposeType;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.VisitType;
+import jakarta.validation.constraints.NotBlank;
 import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Positive;
 import lombok.Getter;
@@ -16,8 +19,8 @@ import lombok.NoArgsConstructor;
 public class CalculationRequest {
 
     /** 보험 ID */
-    @NotNull
-    private Long insuranceId;
+    @NotBlank
+    private String insuranceId;
 
     /** 의료비 */
     @NotNull
@@ -38,4 +41,12 @@ public class CalculationRequest {
 
     /** EDI 코드 (선택) */
     private String ediCode;
+
+    /** 병원 유형 */
+    @NotNull
+    private HospitalType hospitalType;
+
+    /** 급여 여부 */
+    @NotNull
+    private PayType payType;
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/dto/CalculationResponse.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/dto/CalculationResponse.java
@@ -1,10 +1,17 @@
 package com.silsonfit.silsonfit_api.domain.calculation.dto;
 
+import com.silsonfit.silsonfit_api.domain.calculation.entity.CoverageRule;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.CoverageStatus;
 import com.silsonfit.silsonfit_api.domain.calculation.vo.CalculationResult;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceInfoDto;
 import lombok.Builder;
 import lombok.Getter;
 
+import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
+import java.util.stream.Collectors;
+import java.util.stream.Stream;
 
 /**
  * 실손 보험 계산 응답 DTO
@@ -13,8 +20,13 @@ import java.util.List;
 @Builder
 public class CalculationResponse {
 
+    private static final String DEFAULT_DISCLAIMER =
+            "본 계산 결과는 입력하신 정보를 바탕으로 AI가 산출한 참고용 결과입니다. "
+                    + "실제 금액은 가입자 개인의 조건에 따라 차이가 발생하거나 지급이 제한될 수 있습니다. "
+                    + "정확한 금액은 보험사를 통해 확인하시기 바랍니다";
+
     /** 보장 여부 */
-    private Boolean isCovered;
+    private CoverageStatus isCovered;
 
     /** 예상 환급액 */
     private Integer refundAmount;
@@ -23,19 +35,140 @@ public class CalculationResponse {
     private Integer deductibleAmount;
 
     /** 계산 근거 */
-    private List<String> basis;
+    private String basis;
+
+    /** 공제 기준 */
+    private String deductibleBasis;
 
     /** 면책/주의사항 */
     private String disclaimer;
 
+    /** 진료 정보 */
+    private List<String> treatmentInfos;
+
+    /** 총 진료비 */
+    private Integer totalMedicalCost;
+
+    /** 보험 이름 */
+    private String productName;
+
+    /** 보험 회사 */
+    private String companyName;
+
+    /** 보험 정보 */
+    private List<String> insuranceInfos;
+
+    /** 가입 날짜 */
+    private String joinDate;
+
+    /** 자기부담금 비율 */
+    private Integer deductibleRate;
+
+    /** 예상 환급 비율 */
+    private Integer refundRate;
+
+    /** EDI 코드 */
+    private String ediCode;
+
     /** VO → DTO 변환 */
-    public static CalculationResponse from(CalculationResult result) {
+    public static CalculationResponse from(
+            CalculationRequest request,
+            CoverageRule coverageRule,
+            CalculationResult result,
+            InsuranceInfoDto insuranceInfo
+    ) {
         return CalculationResponse.builder()
-                .isCovered(result.getIsCovered())
+                .isCovered(toCoverageStatus(result))
                 .refundAmount(result.getRefundAmount())
                 .deductibleAmount(result.getDeductibleAmount())
-                .basis(result.getBasis())
-                .disclaimer(result.getDisclaimer())
+                .basis(joinBasis(result.getBasis()))
+                .deductibleBasis(createDeductibleBasis(coverageRule, result))
+                .disclaimer(resolveDisclaimer(result.getDisclaimer()))
+                .treatmentInfos(createTreatmentInfos(request))
+                .totalMedicalCost(request.getMedicalCost())
+                .productName(insuranceInfo.productName())
+                .companyName(insuranceInfo.companyName())
+                .insuranceInfos(createInsuranceInfos(insuranceInfo))
+                .joinDate(insuranceInfo.subscribedAt())
+                .deductibleRate(calculateRate(result.getDeductibleAmount(), request.getMedicalCost()))
+                .refundRate(calculateRate(result.getRefundAmount(), request.getMedicalCost()))
+                .ediCode(request.getEdiCode())
                 .build();
+    }
+
+    private static CoverageStatus toCoverageStatus(CalculationResult result) {
+        if (!result.getIsCovered()) {
+            return CoverageStatus.NOT_COVERED;
+        }
+
+        if (result.getDeductibleAmount() > 0) {
+            return CoverageStatus.PARTIAL_COVERED;
+        }
+
+        return CoverageStatus.COVERED;
+    }
+
+    private static String joinBasis(List<String> basis) {
+        if (basis == null || basis.isEmpty()) {
+            return "";
+        }
+
+        return String.join(" ", basis);
+    }
+
+    private static String createDeductibleBasis(CoverageRule coverageRule, CalculationResult result) {
+        if (!result.getIsCovered()) {
+            return "보장 제외로 진료비 전액 자기부담";
+        }
+
+        int deductibleRate = 100 - coverageRule.getCoverageRate();
+        return String.format(
+                "%,d원 또는 진료비의 %d%% 중 큰 금액",
+                coverageRule.getDeductibleAmount(),
+                deductibleRate
+        );
+    }
+
+    private static String resolveDisclaimer(String disclaimer) {
+        if (disclaimer == null || disclaimer.isBlank()) {
+            return DEFAULT_DISCLAIMER;
+        }
+
+        return disclaimer;
+    }
+
+    private static List<String> createTreatmentInfos(CalculationRequest request) {
+        return Stream.of(
+                        request.getVisitType().getDescription(),
+                        request.getTreatmentCategory().getDescription(),
+                        request.getPayType().getDescription()
+                )
+                .filter(Objects::nonNull)
+                .toList();
+    }
+
+    private static List<String> createInsuranceInfos(InsuranceInfoDto insuranceInfo) {
+        List<String> insuranceInfos = new ArrayList<>();
+        insuranceInfos.add(insuranceInfo.generation() + "세대");
+
+        if (insuranceInfo.coverageStructure() != null) {
+            insuranceInfos.add(insuranceInfo.coverageStructure().getDisplayName());
+        }
+
+        if (insuranceInfo.hasNonCoveredRider()) {
+            insuranceInfos.add("비급여특약");
+        }
+
+        return insuranceInfos.stream()
+                .filter(info -> info != null && !info.isBlank())
+                .collect(Collectors.toList());
+    }
+
+    private static Integer calculateRate(Integer amount, Integer totalAmount) {
+        if (totalAmount == null || totalAmount == 0) {
+            return 0;
+        }
+
+        return Math.round(amount * 100.0f / totalAmount);
     }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/CoverageStatus.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/CoverageStatus.java
@@ -1,0 +1,11 @@
+package com.silsonfit.silsonfit_api.domain.calculation.enums;
+
+/**
+ * 보장 상태
+ */
+public enum CoverageStatus {
+
+    COVERED,
+    PARTIAL_COVERED,
+    NOT_COVERED
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/HospitalType.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/HospitalType.java
@@ -1,0 +1,19 @@
+package com.silsonfit.silsonfit_api.domain.calculation.enums;
+
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+
+/**
+ * 병원 유형
+ */
+@Getter
+@RequiredArgsConstructor
+public enum HospitalType {
+
+    CLINIC("의원"),
+    GENERAL_HOSPITAL("종합병원"),
+    TERTIARY_HOSPITAL("상급종합병원"),
+    UNKNOWN("병원 유형 모름");
+
+    private final String description;
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/InsuranceGeneration.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/InsuranceGeneration.java
@@ -17,4 +17,15 @@ public enum InsuranceGeneration {
     FIFTH("5세대");
 
     private final String description;
+
+    public static InsuranceGeneration from(int generation) {
+        return switch (generation) {
+            case 1 -> FIRST;
+            case 2 -> SECOND;
+            case 3 -> THIRD;
+            case 4 -> FOURTH;
+            case 5 -> FIFTH;
+            default -> FOURTH;
+        };
+    }
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/PayType.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/PayType.java
@@ -11,7 +11,8 @@ import lombok.RequiredArgsConstructor;
 public enum PayType {
 
     PAY("급여"),
-    NON_PAY("비급여");
+    NON_PAY("비급여"),
+    UNKNOWN("급여 여부 모름");
 
     private final String description;
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/PurposeType.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/PurposeType.java
@@ -11,7 +11,7 @@ import lombok.RequiredArgsConstructor;
 public enum PurposeType {
 
     TREATMENT("치료 목적"),
-    CHECKUP("단순 검사"),
+    EXAMINATION("검사 목적"),
     UNKNOWN("잘 모름");
 
     private final String description;

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/TreatmentCategory.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/TreatmentCategory.java
@@ -10,13 +10,13 @@ import lombok.RequiredArgsConstructor;
 @RequiredArgsConstructor
 public enum TreatmentCategory {
 
+    GENERAL("일반진료"),
     MRI("MRI"),
     CT("CT"),
-    MANUAL_THERAPY("도수치료"),
-    SHOCKWAVE_THERAPY("체외충격파"),
+    CHIROPRACTIC("도수치료"),
+    EMERGENCY("응급"),
     INJECTION("주사"),
-    PHYSICAL_THERAPY("물리치료"),
-    GENERAL_TREATMENT("일반진료");
+    PHYSICAL_THERAPY("물리치료");
 
     private final String description;
 }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationService.java
@@ -8,11 +8,13 @@ import com.silsonfit.silsonfit_api.domain.calculation.enums.InsuranceGeneration;
 import com.silsonfit.silsonfit_api.domain.calculation.repository.CalculationHistoryRepository;
 import com.silsonfit.silsonfit_api.domain.calculation.vo.CalculationResult;
 import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleContext;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceInfoDto;
+import com.silsonfit.silsonfit_api.domain.insurance.service.InsuranceService;
+import com.silsonfit.silsonfit_api.global.error.BusinessException;
+import com.silsonfit.silsonfit_api.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.List;
 
 /**
  * 실손 보험 계산 Service
@@ -27,6 +29,7 @@ public class CalculationService {
 
     private final CoverageRuleResolver coverageRuleResolver;
     private final CalculationHistoryRepository calculationHistoryRepository;
+    private final InsuranceService insuranceService;
 
     /**
      * 실손 보험 예상 환급액 계산
@@ -37,10 +40,12 @@ public class CalculationService {
      */
     @Transactional
     public CalculationResponse calculate(Long userId, CalculationRequest request) {
-        // TODO(calculation): 보험 도메인 연동 후 insuranceId 기반 보험 세대/약관 조회로 대체한다.
+        Long userInsuranceId = parseUserInsuranceId(request.getInsuranceId());
+        InsuranceInfoDto insuranceInfo = insuranceService.getInsuranceInfo(userInsuranceId);
+
         CoverageRuleContext context = new CoverageRuleContext(
-                request.getInsuranceId(),
-                InsuranceGeneration.FOURTH
+                insuranceInfo.insuranceId(),
+                InsuranceGeneration.from(insuranceInfo.generation())
         );
 
         CoverageRule coverageRule = coverageRuleResolver.resolve(
@@ -52,8 +57,8 @@ public class CalculationService {
         );
 
         CalculationResult result = calculateByRule(request.getMedicalCost(), coverageRule);
-        saveHistory(userId, request, result);
-        return CalculationResponse.from(result);
+        saveHistory(userId, userInsuranceId, request, result);
+        return CalculationResponse.from(request, coverageRule, result, insuranceInfo);
     }
 
     /**
@@ -61,12 +66,13 @@ public class CalculationService {
      */
     private void saveHistory(
             Long userId,
+            Long userInsuranceId,
             CalculationRequest request,
             CalculationResult result
     ) {
         CalculationHistory history = CalculationHistory.create(
                 userId,
-                request.getInsuranceId(),
+                userInsuranceId,
                 request.getMedicalCost(),
                 request.getTreatmentCategory(),
                 request.getEdiCode(),
@@ -76,6 +82,26 @@ public class CalculationService {
         );
 
         calculationHistoryRepository.save(history);
+    }
+
+    /**
+     * 클라이언트 표시용 보험 ID(ins_123)와 숫자 ID를 모두 사용자 보험 등록 ID로 해석한다.
+     */
+    private Long parseUserInsuranceId(String insuranceId) {
+        if (insuranceId == null || insuranceId.isBlank()) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
+
+        String normalizedInsuranceId = insuranceId.trim();
+        if (normalizedInsuranceId.startsWith("ins_")) {
+            normalizedInsuranceId = normalizedInsuranceId.substring("ins_".length());
+        }
+
+        try {
+            return Long.parseLong(normalizedInsuranceId);
+        } catch (NumberFormatException e) {
+            throw new BusinessException(ErrorCode.INVALID_INPUT);
+        }
     }
 
     /**

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleGenerator.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleGenerator.java
@@ -78,10 +78,10 @@ public class CoverageRuleGenerator {
             return TreatmentCategory.CT;
         }
         if (ediCode.containsKeyword("도수")) {
-            return TreatmentCategory.MANUAL_THERAPY;
+            return TreatmentCategory.CHIROPRACTIC;
         }
         if (ediCode.containsKeyword("충격파")) {
-            return TreatmentCategory.SHOCKWAVE_THERAPY;
+            return TreatmentCategory.PHYSICAL_THERAPY;
         }
         if (ediCode.containsKeyword("주사")) {
             return TreatmentCategory.INJECTION;
@@ -90,7 +90,7 @@ public class CoverageRuleGenerator {
             return TreatmentCategory.PHYSICAL_THERAPY;
         }
 
-        return TreatmentCategory.GENERAL_TREATMENT;
+        return TreatmentCategory.GENERAL;
     }
 
     /**
@@ -98,7 +98,7 @@ public class CoverageRuleGenerator {
      */
     private PurposeType resolvePurposeType(EdiCode ediCode) {
         if (ediCode.containsKeyword("검진") || ediCode.containsKeyword("건강검진")) {
-            return PurposeType.CHECKUP;
+            return PurposeType.EXAMINATION;
         }
 
         return PurposeType.TREATMENT;

--- a/silsonfit-api/src/main/resources/data.sql
+++ b/silsonfit-api/src/main/resources/data.sql
@@ -1,6 +1,5 @@
 -- 개발용 EDI 미입력 fallback CoverageRule seed
 -- 운영 환경에서는 Flyway 또는 관리자 API로 관리한다.
-
 insert into coverage_rule (
     insurance_id,
     generation,
@@ -15,150 +14,134 @@ insert into coverage_rule (
     basis,
     disclaimer
 ) values
--- 1세대: 자기부담이 거의 없는 한도 중심 러프 룰
-(
-    null, 'FIRST', null, 'OUTPATIENT', 'MRI', 'TREATMENT',
-    true, 100, 0, null,
-    '["개발용 1세대 외래 MRI fallback 보장 룰","1세대는 자기부담이 거의 없는 구조로 러프 계산"]',
-    '개발용 임시 보장 룰입니다.'
+-- 1세대: 보장 범위가 넓은 편이나 상품별 차이가 커서 보수적 fallback
+(null, 'FIRST', null, 'OUTPATIENT', 'GENERAL', 'TREATMENT',
+ true, 90, 5000, null,
+ '["1세대 실손 외래 일반진료 기본 보장 추정","상품별 약관 차이가 있어 보수적 fallback 기준 적용"]',
+ '실제 보험금은 가입 상품 약관, 병원 구분, 급여/비급여 여부, 면책 조항에 따라 달라질 수 있습니다.'
 ),
-(
-    null, 'FIRST', null, 'OUTPATIENT', 'CT', 'TREATMENT',
-    true, 100, 0, null,
-    '["개발용 1세대 외래 CT fallback 보장 룰","1세대는 자기부담이 거의 없는 구조로 러프 계산"]',
-    '개발용 임시 보장 룰입니다.'
+(null, 'FIRST', null, 'OUTPATIENT', 'CT', 'TREATMENT',
+ true, 90, 10000, null,
+ '["1세대 실손 외래 CT 치료 목적 보장 추정","고액 검사 항목은 상품별 한도 차이가 있어 보수적 fallback 기준 적용"]',
+ '실제 보험금은 가입 상품 약관, 병원 구분, 급여/비급여 여부, 면책 조항에 따라 달라질 수 있습니다.'
 ),
-(
-    null, 'FIRST', null, 'OUTPATIENT', 'GENERAL_TREATMENT', 'TREATMENT',
-    true, 100, 0, null,
-    '["개발용 1세대 외래 일반진료 fallback 보장 룰","1세대는 급여/비급여 대부분을 넓게 보장하는 구조로 러프 계산"]',
-    '개발용 임시 보장 룰입니다.'
+(null, 'FIRST', null, 'OUTPATIENT', 'MRI', 'TREATMENT',
+ true, 90, 10000, null,
+ '["1세대 실손 외래 MRI 치료 목적 보장 추정","고액 검사 항목은 상품별 한도 차이가 있어 보수적 fallback 기준 적용"]',
+ '실제 보험금은 가입 상품 약관, 병원 구분, 급여/비급여 여부, 면책 조항에 따라 달라질 수 있습니다.'
 ),
-(
-    null, 'FIRST', null, 'MEDICATION', 'GENERAL_TREATMENT', 'TREATMENT',
-    true, 100, 0, null,
-    '["개발용 1세대 약제 fallback 보장 룰","1세대는 자기부담이 거의 없는 구조로 러프 계산"]',
-    '개발용 임시 보장 룰입니다.'
+(null, 'FIRST', null, 'MEDICATION', 'GENERAL', 'TREATMENT',
+ true, 90, 5000, null,
+ '["1세대 실손 약제비 보장 추정","상품별 약제비 공제 기준 차이가 있어 보수적 fallback 기준 적용"]',
+ '실제 보험금은 가입 상품 약관, 처방 여부, 약제 구분, 면책 조항에 따라 달라질 수 있습니다.'
 ),
 
--- 2세대: 자기부담 도입을 반영한 러프 룰
-(
-    null, 'SECOND', null, 'OUTPATIENT', 'MRI', 'TREATMENT',
-    true, 80, 20000, null,
-    '["개발용 2세대 외래 MRI fallback 보장 룰","2세대는 자기부담 도입 구조를 반영한 러프 계산"]',
-    '개발용 임시 보장 룰입니다.'
+-- 2세대: 자기부담 구조를 반영한 fallback
+(null, 'SECOND', null, 'OUTPATIENT', 'GENERAL', 'TREATMENT',
+ true, 90, 10000, null,
+ '["2세대 실손 외래 일반진료 보장 추정","외래 자기부담금 구조를 반영한 fallback 기준 적용"]',
+ '실제 보험금은 가입 상품 약관, 병원 구분, 급여/비급여 여부, 면책 조항에 따라 달라질 수 있습니다.'
 ),
-(
-    null, 'SECOND', null, 'OUTPATIENT', 'CT', 'TREATMENT',
-    true, 80, 20000, null,
-    '["개발용 2세대 외래 CT fallback 보장 룰","2세대는 자기부담 도입 구조를 반영한 러프 계산"]',
-    '개발용 임시 보장 룰입니다.'
+(null, 'SECOND', null, 'OUTPATIENT', 'CT', 'TREATMENT',
+ true, 80, 20000, null,
+ '["2세대 실손 외래 CT 치료 목적 보장 추정","고액 검사 항목은 자기부담금을 높게 반영한 fallback 기준 적용"]',
+ '실제 보험금은 가입 상품 약관, 병원 구분, 급여/비급여 여부, 면책 조항에 따라 달라질 수 있습니다.'
 ),
-(
-    null, 'SECOND', null, 'OUTPATIENT', 'GENERAL_TREATMENT', 'TREATMENT',
-    true, 90, 10000, null,
-    '["개발용 2세대 외래 일반진료 fallback 보장 룰","2세대 급여성 진료는 낮은 자기부담 기준으로 러프 계산"]',
-    '개발용 임시 보장 룰입니다.'
+(null, 'SECOND', null, 'OUTPATIENT', 'MRI', 'TREATMENT',
+ true, 80, 20000, null,
+ '["2세대 실손 외래 MRI 치료 목적 보장 추정","고액 검사 항목은 자기부담금을 높게 반영한 fallback 기준 적용"]',
+ '실제 보험금은 가입 상품 약관, 병원 구분, 급여/비급여 여부, 면책 조항에 따라 달라질 수 있습니다.'
 ),
-(
-    null, 'SECOND', null, 'MEDICATION', 'GENERAL_TREATMENT', 'TREATMENT',
-    true, 90, 8000, null,
-    '["개발용 2세대 약제 fallback 보장 룰","2세대 약제비는 낮은 자기부담 기준으로 러프 계산"]',
-    '개발용 임시 보장 룰입니다.'
+(null, 'SECOND', null, 'MEDICATION', 'GENERAL', 'TREATMENT',
+ true, 90, 8000, null,
+ '["2세대 실손 약제비 보장 추정","약제비 자기부담금 구조를 반영한 fallback 기준 적용"]',
+ '실제 보험금은 가입 상품 약관, 처방 여부, 약제 구분, 면책 조항에 따라 달라질 수 있습니다.'
 ),
 
--- 3세대: 기본계약 급여 영역 + 비급여 특약 분리 러프 룰
-(
-    null, 'THIRD', null, 'OUTPATIENT', 'GENERAL_TREATMENT', 'TREATMENT',
-    true, 80, 10000, null,
-    '["개발용 3세대 외래 일반진료 fallback 보장 룰","3세대 기본계약 급여 영역 기준 러프 계산"]',
-    '개발용 임시 보장 룰입니다.'
+-- 3세대: 급여 기본계약 + 3대 비급여 특약 분리 구조 반영
+(null, 'THIRD', null, 'OUTPATIENT', 'GENERAL', 'TREATMENT',
+ true, 80, 10000, null,
+ '["3세대 실손 외래 일반진료 보장 추정","급여성 기본계약 영역 기준 fallback 적용"]',
+ '실제 보험금은 가입 상품 약관, 급여/비급여 여부, 특약 가입 여부에 따라 달라질 수 있습니다.'
 ),
-(
-    null, 'THIRD', null, 'MEDICATION', 'GENERAL_TREATMENT', 'TREATMENT',
-    true, 80, 10000, null,
-    '["개발용 3세대 약제 fallback 보장 룰","3세대 기본계약 급여 영역 기준 러프 계산"]',
-    '개발용 임시 보장 룰입니다.'
+(null, 'THIRD', null, 'MEDICATION', 'GENERAL', 'TREATMENT',
+ true, 80, 10000, null,
+ '["3세대 실손 약제비 보장 추정","급여성 기본계약 영역 기준 fallback 적용"]',
+ '실제 보험금은 가입 상품 약관, 처방 여부, 약제 구분, 면책 조항에 따라 달라질 수 있습니다.'
 ),
-(
-    null, 'THIRD', null, 'OUTPATIENT', 'MRI', 'TREATMENT',
-    true, 70, 30000, null,
-    '["개발용 3세대 외래 MRI 비급여 특약 fallback 보장 룰","3세대는 비급여를 특약으로 분리하는 구조를 반영"]',
-    '개발용 임시 보장 룰입니다.'
+(null, 'THIRD', null, 'OUTPATIENT', 'MRI', 'TREATMENT',
+ true, 70, 30000, null,
+ '["3세대 실손 MRI 비급여 특약 보장 추정","3대 비급여 특약 항목은 높은 자기부담 기준 fallback 적용"]',
+ 'MRI 특약 미가입, 건강검진 목적, 예방 목적, 미용 목적 진료는 보장되지 않을 수 있습니다.'
 ),
-(
-    null, 'THIRD', null, 'OUTPATIENT', 'CT', 'TREATMENT',
-    true, 70, 30000, null,
-    '["개발용 3세대 외래 CT fallback 보장 룰","3세대 고액 검사 항목은 높은 자기부담 기준으로 러프 계산"]',
-    '개발용 임시 보장 룰입니다.'
+(null, 'THIRD', null, 'OUTPATIENT', 'CHIROPRACTIC', 'TREATMENT',
+ true, 70, 30000, null,
+ '["3세대 실손 도수치료 비급여 특약 보장 추정","3대 비급여 특약 항목은 높은 자기부담 기준 fallback 적용"]',
+ '도수치료 특약 미가입, 횟수 제한 초과, 의학적 필요성 부족 시 보장되지 않을 수 있습니다.'
 ),
-(
-    null, 'THIRD', null, 'OUTPATIENT', 'MANUAL_THERAPY', 'TREATMENT',
-    true, 70, 30000, null,
-    '["개발용 3세대 외래 도수치료 비급여 특약 fallback 보장 룰","3세대 비급여 특약 분리 항목 기준 러프 계산"]',
-    '개발용 임시 보장 룰입니다.'
+(null, 'THIRD', null, 'OUTPATIENT', 'PHYSICAL_THERAPY', 'TREATMENT',
+ true, 70, 30000, null,
+ '["3세대 실손 체외충격파 비급여 특약 보장 추정","3대 비급여 특약 항목은 높은 자기부담 기준 fallback 적용"]',
+ '체외충격파 특약 미가입, 횟수 제한 초과, 의학적 필요성 부족 시 보장되지 않을 수 있습니다.'
 ),
-(
-    null, 'THIRD', null, 'OUTPATIENT', 'SHOCKWAVE_THERAPY', 'TREATMENT',
-    true, 70, 30000, null,
-    '["개발용 3세대 외래 체외충격파 비급여 특약 fallback 보장 룰","3세대 비급여 특약 분리 항목 기준 러프 계산"]',
-    '개발용 임시 보장 룰입니다.'
-),
-(
-    null, 'THIRD', null, 'OUTPATIENT', 'INJECTION', 'TREATMENT',
-    true, 70, 30000, null,
-    '["개발용 3세대 외래 주사치료 비급여 특약 fallback 보장 룰","3세대 비급여 특약 분리 항목 기준 러프 계산"]',
-    '개발용 임시 보장 룰입니다.'
+(null, 'THIRD', null, 'OUTPATIENT', 'INJECTION', 'TREATMENT',
+ true, 70, 30000, null,
+ '["3세대 실손 비급여 주사치료 특약 보장 추정","3대 비급여 특약 항목은 높은 자기부담 기준 fallback 적용"]',
+ '비급여 주사 특약 미가입, 예방·영양·미용 목적 주사는 보장되지 않을 수 있습니다.'
 ),
 
--- 4세대: 급여/비급여 분리와 높은 비급여 자기부담을 반영한 러프 룰
-(
-    null, 'FOURTH', null, 'OUTPATIENT', 'GENERAL_TREATMENT', 'TREATMENT',
-    true, 80, 10000, null,
-    '["개발용 4세대 외래 일반진료 fallback 보장 룰","4세대 급여 영역 기준 러프 계산"]',
-    '개발용 임시 보장 룰입니다.'
+-- 4세대: 급여/비급여 분리 및 비급여 자기부담 강화 구조 반영
+(null, 'FOURTH', null, 'OUTPATIENT', 'GENERAL', 'TREATMENT',
+ true, 80, 10000, null,
+ '["4세대 실손 외래 일반진료 보장 추정","급여 영역 기준 fallback 적용"]',
+ '실제 보험금은 급여/비급여 여부, 병원 구분, 가입 약관에 따라 달라질 수 있습니다.'
 ),
-(
-    null, 'FOURTH', null, 'MEDICATION', 'GENERAL_TREATMENT', 'TREATMENT',
-    true, 80, 10000, null,
-    '["개발용 4세대 약제 fallback 보장 룰","4세대 급여 영역 기준 러프 계산"]',
-    '개발용 임시 보장 룰입니다.'
+(null, 'FOURTH', null, 'MEDICATION', 'GENERAL', 'TREATMENT',
+ true, 80, 10000, null,
+ '["4세대 실손 약제비 보장 추정","급여 영역 기준 fallback 적용"]',
+ '실제 보험금은 처방 여부, 약제 구분, 가입 약관에 따라 달라질 수 있습니다.'
 ),
-(
-    null, 'FOURTH', null, 'OUTPATIENT', 'MRI', 'TREATMENT',
-    true, 70, 30000, null,
-    '["개발용 4세대 외래 MRI 비급여 fallback 보장 룰","4세대 비급여 자기부담 기준 러프 계산"]',
-    '개발용 임시 보장 룰입니다.'
+(null, 'FOURTH', null, 'OUTPATIENT', 'MRI', 'TREATMENT',
+ true, 70, 30000, null,
+ '["4세대 실손 MRI 비급여 보장 추정","비급여 항목은 높은 자기부담 기준 fallback 적용"]',
+ 'MRI 특약 미가입, 건강검진 목적, 예방 목적, 미용 목적 진료는 보장되지 않을 수 있습니다.'
 ),
-(
-    null, 'FOURTH', null, 'OUTPATIENT', 'CT', 'TREATMENT',
-    true, 70, 30000, null,
-    '["개발용 4세대 외래 CT fallback 보장 룰","4세대 고액 검사 항목 기준 러프 계산"]',
-    '개발용 임시 보장 룰입니다.'
+(null, 'FOURTH', null, 'OUTPATIENT', 'CHIROPRACTIC', 'TREATMENT',
+ true, 70, 30000, null,
+ '["4세대 실손 도수치료 비급여 보장 추정","비급여 항목은 높은 자기부담 기준 fallback 적용"]',
+ '도수치료는 횟수 제한, 증상 개선 여부, 의학적 필요성에 따라 보장 여부가 달라질 수 있습니다.'
 ),
-(
-    null, 'FOURTH', null, 'OUTPATIENT', 'MANUAL_THERAPY', 'TREATMENT',
-    true, 70, 30000, null,
-    '["개발용 4세대 외래 도수치료 비급여 fallback 보장 룰","4세대 비급여 자기부담 기준 러프 계산"]',
-    '개발용 임시 보장 룰입니다.'
+(null, 'FOURTH', null, 'OUTPATIENT', 'PHYSICAL_THERAPY', 'TREATMENT',
+ true, 70, 30000, null,
+ '["4세대 실손 체외충격파 비급여 보장 추정","비급여 항목은 높은 자기부담 기준 fallback 적용"]',
+ '체외충격파 치료는 횟수 제한, 의학적 필요성에 따라 보장 여부가 달라질 수 있습니다.'
 ),
-(
-    null, 'FOURTH', null, 'OUTPATIENT', 'SHOCKWAVE_THERAPY', 'TREATMENT',
-    true, 70, 30000, null,
-    '["개발용 4세대 외래 체외충격파 비급여 fallback 보장 룰","4세대 비급여 자기부담 기준 러프 계산"]',
-    '개발용 임시 보장 룰입니다.'
+(null, 'FOURTH', null, 'OUTPATIENT', 'INJECTION', 'TREATMENT',
+ true, 70, 30000, null,
+ '["4세대 실손 비급여 주사치료 보장 추정","비급여 항목은 높은 자기부담 기준 fallback 적용"]',
+ '영양제, 예방, 미용 목적 주사는 보장되지 않을 수 있습니다.'
 ),
-(
-    null, 'FOURTH', null, 'OUTPATIENT', 'INJECTION', 'TREATMENT',
-    true, 70, 30000, null,
-    '["개발용 4세대 외래 주사치료 비급여 fallback 보장 룰","4세대 비급여 자기부담 기준 러프 계산"]',
-    '개발용 임시 보장 룰입니다.'
+
+-- 공통 비보장 fallback
+(null, 'FIRST', null, 'OUTPATIENT', 'GENERAL', 'EXAMINATION',
+ false, 0, 0, null,
+ '["건강검진 목적 진료는 실손 보장 대상에서 제외될 수 있음","치료 목적이 아닌 예방·검진 목적 기준 비보장 처리"]',
+ '치료 목적이 확인되는 경우 실제 보장 여부는 약관 기준으로 재검토가 필요합니다.'
 ),
-(
-    null, 'FOURTH', null, 'OUTPATIENT', 'MRI', 'CHECKUP',
-    false, 0, 0, null,
-    '["개발용 MRI 검진 목적 비보장 fallback 룰","건강검진 목적은 보장 제외 임시 기준"]',
-    '개발용 임시 보장 룰입니다.'
+(null, 'SECOND', null, 'OUTPATIENT', 'GENERAL', 'EXAMINATION',
+ false, 0, 0, null,
+ '["건강검진 목적 진료는 실손 보장 대상에서 제외될 수 있음","치료 목적이 아닌 예방·검진 목적 기준 비보장 처리"]',
+ '치료 목적이 확인되는 경우 실제 보장 여부는 약관 기준으로 재검토가 필요합니다.'
+),
+(null, 'THIRD', null, 'OUTPATIENT', 'GENERAL', 'EXAMINATION',
+ false, 0, 0, null,
+ '["건강검진 목적 진료는 실손 보장 대상에서 제외될 수 있음","치료 목적이 아닌 예방·검진 목적 기준 비보장 처리"]',
+ '치료 목적이 확인되는 경우 실제 보장 여부는 약관 기준으로 재검토가 필요합니다.'
+),
+(null, 'FOURTH', null, 'OUTPATIENT', 'GENERAL', 'EXAMINATION',
+ false, 0, 0, null,
+ '["건강검진 목적 진료는 실손 보장 대상에서 제외될 수 있음","치료 목적이 아닌 예방·검진 목적 기준 비보장 처리"]',
+ '치료 목적이 확인되는 경우 실제 보장 여부는 약관 기준으로 재검토가 필요합니다.'
 );
 
 -- 개발용 보험 상품 seed

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationControllerTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationControllerTest.java
@@ -2,6 +2,9 @@ package com.silsonfit.silsonfit_api.domain.calculation.controller;
 
 import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationRequest;
 import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationResponse;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.CoverageStatus;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.HospitalType;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.PayType;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.PurposeType;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.VisitType;
@@ -41,11 +44,21 @@ class CalculationControllerTest {
     @DisplayName("계산 요청을 처리하고 ApiResponse로 계산 결과를 반환한다")
     void calculate_success() throws Exception {
         CalculationResponse response = CalculationResponse.builder()
-                .isCovered(true)
+                .isCovered(CoverageStatus.PARTIAL_COVERED)
                 .refundAmount(70000)
                 .deductibleAmount(30000)
-                .basis(List.of("계산 근거"))
+                .basis("계산 근거")
+                .deductibleBasis("30,000원 또는 진료비의 30% 중 큰 금액")
                 .disclaimer("주의사항")
+                .treatmentInfos(List.of("외래", "MRI", "비급여"))
+                .totalMedicalCost(100000)
+                .productName("무배당 실손의료비보험")
+                .companyName("삼성화재")
+                .insuranceInfos(List.of("4세대", "3대비급여"))
+                .joinDate("2025-04")
+                .deductibleRate(30)
+                .refundRate(70)
+                .ediCode("EDI001")
                 .build();
 
         when(calculationService.calculate(eq(1L), any())).thenReturn(response);
@@ -56,34 +69,51 @@ class CalculationControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "insuranceId": 1,
+                                  "insuranceId": "ins_1",
                                   "medicalCost": 100000,
                                   "visitType": "OUTPATIENT",
                                   "treatmentCategory": "MRI",
                                   "purposeType": "TREATMENT",
-                                  "ediCode": "EDI001"
+                                  "ediCode": "EDI001",
+                                  "hospitalType": "GENERAL_HOSPITAL",
+                                  "payType": "NON_PAY"
                                 }
                                 """))
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.data.isCovered").value(true))
+                .andExpect(jsonPath("$.data.isCovered").value("PARTIAL_COVERED"))
                 .andExpect(jsonPath("$.data.refundAmount").value(70000))
                 .andExpect(jsonPath("$.data.deductibleAmount").value(30000))
-                .andExpect(jsonPath("$.data.basis[0]").value("계산 근거"))
-                .andExpect(jsonPath("$.data.disclaimer").value("주의사항"));
+                .andExpect(jsonPath("$.data.basis").value("계산 근거"))
+                .andExpect(jsonPath("$.data.deductibleBasis").value("30,000원 또는 진료비의 30% 중 큰 금액"))
+                .andExpect(jsonPath("$.data.disclaimer").value("주의사항"))
+                .andExpect(jsonPath("$.data.treatmentInfos[0]").value("외래"))
+                .andExpect(jsonPath("$.data.treatmentInfos[1]").value("MRI"))
+                .andExpect(jsonPath("$.data.treatmentInfos[2]").value("비급여"))
+                .andExpect(jsonPath("$.data.totalMedicalCost").value(100000))
+                .andExpect(jsonPath("$.data.productName").value("무배당 실손의료비보험"))
+                .andExpect(jsonPath("$.data.companyName").value("삼성화재"))
+                .andExpect(jsonPath("$.data.insuranceInfos[0]").value("4세대"))
+                .andExpect(jsonPath("$.data.insuranceInfos[1]").value("3대비급여"))
+                .andExpect(jsonPath("$.data.joinDate").value("2025-04"))
+                .andExpect(jsonPath("$.data.deductibleRate").value(30))
+                .andExpect(jsonPath("$.data.refundRate").value(70))
+                .andExpect(jsonPath("$.data.ediCode").value("EDI001"));
 
         org.mockito.ArgumentCaptor<CalculationRequest> requestCaptor =
                 org.mockito.ArgumentCaptor.forClass(CalculationRequest.class);
         verify(calculationService).calculate(eq(1L), requestCaptor.capture());
 
         CalculationRequest capturedRequest = requestCaptor.getValue();
-        assertThat(capturedRequest.getInsuranceId()).isEqualTo(1L);
+        assertThat(capturedRequest.getInsuranceId()).isEqualTo("ins_1");
         assertThat(capturedRequest.getMedicalCost()).isEqualTo(100000);
         assertThat(capturedRequest.getVisitType()).isEqualTo(VisitType.OUTPATIENT);
         assertThat(capturedRequest.getTreatmentCategory()).isEqualTo(TreatmentCategory.MRI);
         assertThat(capturedRequest.getPurposeType()).isEqualTo(PurposeType.TREATMENT);
         assertThat(capturedRequest.getEdiCode()).isEqualTo("EDI001");
+        assertThat(capturedRequest.getHospitalType()).isEqualTo(HospitalType.GENERAL_HOSPITAL);
+        assertThat(capturedRequest.getPayType()).isEqualTo(PayType.NON_PAY);
     }
 
     @Test
@@ -95,10 +125,12 @@ class CalculationControllerTest {
                         .contentType(MediaType.APPLICATION_JSON)
                         .content("""
                                 {
-                                  "insuranceId": 1,
+                                  "insuranceId": "ins_1",
                                   "medicalCost": 100000,
                                   "visitType": "OUTPATIENT",
-                                  "treatmentCategory": "MRI"
+                                  "treatmentCategory": "MRI",
+                                  "hospitalType": "GENERAL_HOSPITAL",
+                                  "payType": "NON_PAY"
                                 }
                                 """))
                 .andExpect(status().isBadRequest())

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationHistoryServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationHistoryServiceTest.java
@@ -43,7 +43,7 @@ class CalculationHistoryServiceTest {
         ));
         CalculationHistory secondHistory = calculationHistoryRepository.save(createHistory(
                 1L,
-                TreatmentCategory.GENERAL_TREATMENT,
+                TreatmentCategory.GENERAL,
                 100000,
                 70000,
                 true

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationServiceTest.java
@@ -4,12 +4,22 @@ import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationRequest;
 import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationResponse;
 import com.silsonfit.silsonfit_api.domain.calculation.entity.CalculationHistory;
 import com.silsonfit.silsonfit_api.domain.calculation.entity.CoverageRule;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.CoverageStatus;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.HospitalType;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.InsuranceGeneration;
+import com.silsonfit.silsonfit_api.domain.calculation.enums.PayType;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.PurposeType;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.VisitType;
 import com.silsonfit.silsonfit_api.domain.calculation.repository.CalculationHistoryRepository;
 import com.silsonfit.silsonfit_api.domain.calculation.repository.CoverageRuleRepository;
+import com.silsonfit.silsonfit_api.domain.insurance.entity.Insurance;
+import com.silsonfit.silsonfit_api.domain.insurance.entity.UserInsurance;
+import com.silsonfit.silsonfit_api.domain.insurance.enums.CautionPoint;
+import com.silsonfit.silsonfit_api.domain.insurance.enums.ContractType;
+import com.silsonfit.silsonfit_api.domain.insurance.enums.CoverageStructure;
+import com.silsonfit.silsonfit_api.domain.insurance.repository.InsuranceRepository;
+import com.silsonfit.silsonfit_api.domain.insurance.repository.UserInsuranceRepository;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -24,7 +34,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Transactional
 class CalculationServiceTest {
 
-    private static final Long TEST_INSURANCE_ID = 100L;
+    private static final Long TEST_USER_ID = 1L;
 
     @Autowired
     CalculationService calculationService;
@@ -35,25 +45,42 @@ class CalculationServiceTest {
     @Autowired
     CalculationHistoryRepository calculationHistoryRepository;
 
+    @Autowired
+    InsuranceRepository insuranceRepository;
+
+    @Autowired
+    UserInsuranceRepository userInsuranceRepository;
+
     @Test
     void 보장_대상이면_보장률에_따라_환급액과_자기부담금을_계산한다() {
+        Long userInsuranceId = saveUserInsurance();
         coverageRuleRepository.save(createCoverageRule(
                 true,
                 70,
                 10000,
                 null
         ));
-        CalculationRequest request = createCalculationRequest(100000);
+        CalculationRequest request = createCalculationRequest(userInsuranceId, 100000);
 
-        CalculationResponse response = calculationService.calculate(1L, request);
+        CalculationResponse response = calculationService.calculate(TEST_USER_ID, request);
 
-        assertThat(response.getIsCovered()).isTrue();
+        assertThat(response.getIsCovered()).isEqualTo(CoverageStatus.PARTIAL_COVERED);
         assertThat(response.getRefundAmount()).isEqualTo(70000);
         assertThat(response.getDeductibleAmount()).isEqualTo(30000);
+        assertThat(response.getBasis()).isEqualTo("계산 테스트 룰");
+        assertThat(response.getDeductibleBasis()).isEqualTo("10,000원 또는 진료비의 30% 중 큰 금액");
+        assertThat(response.getTreatmentInfos()).containsExactly("외래", "CT", "급여 여부 모름");
+        assertThat(response.getTotalMedicalCost()).isEqualTo(100000);
+        assertThat(response.getProductName()).isEqualTo("테스트 실손보험");
+        assertThat(response.getCompanyName()).isEqualTo("삼성화재");
+        assertThat(response.getInsuranceInfos()).containsExactly("4세대", "3대비급여", "비급여특약");
+        assertThat(response.getJoinDate()).isEqualTo("2025-04");
+        assertThat(response.getDeductibleRate()).isEqualTo(30);
+        assertThat(response.getRefundRate()).isEqualTo(70);
 
         CalculationHistory history = calculationHistoryRepository.findAll().get(0);
-        assertThat(history.getUserId()).isEqualTo(1L);
-        assertThat(history.getInsuranceId()).isEqualTo(TEST_INSURANCE_ID);
+        assertThat(history.getUserId()).isEqualTo(TEST_USER_ID);
+        assertThat(history.getInsuranceId()).isEqualTo(userInsuranceId);
         assertThat(history.getMedicalCost()).isEqualTo(100000);
         assertThat(history.getTreatmentCategory()).isEqualTo(TreatmentCategory.CT);
         assertThat(history.getRefundAmount()).isEqualTo(70000);
@@ -62,36 +89,39 @@ class CalculationServiceTest {
 
     @Test
     void 고정_자기부담금이_더_크면_고정_자기부담금을_적용한다() {
+        Long userInsuranceId = saveUserInsurance();
         coverageRuleRepository.save(createCoverageRule(
                 true,
                 95,
                 10000,
                 null
         ));
-        CalculationRequest request = createCalculationRequest(100000);
+        CalculationRequest request = createCalculationRequest(userInsuranceId, 100000);
 
-        CalculationResponse response = calculationService.calculate(1L, request);
+        CalculationResponse response = calculationService.calculate(TEST_USER_ID, request);
 
-        assertThat(response.getIsCovered()).isTrue();
+        assertThat(response.getIsCovered()).isEqualTo(CoverageStatus.PARTIAL_COVERED);
         assertThat(response.getRefundAmount()).isEqualTo(90000);
         assertThat(response.getDeductibleAmount()).isEqualTo(10000);
     }
 
     @Test
     void 보장_제외이면_환급액은_0원이고_자기부담금은_의료비_전액이다() {
+        Long userInsuranceId = saveUserInsurance();
         coverageRuleRepository.save(createCoverageRule(
                 false,
                 0,
                 0,
                 null
         ));
-        CalculationRequest request = createCalculationRequest(100000);
+        CalculationRequest request = createCalculationRequest(userInsuranceId, 100000);
 
-        CalculationResponse response = calculationService.calculate(1L, request);
+        CalculationResponse response = calculationService.calculate(TEST_USER_ID, request);
 
-        assertThat(response.getIsCovered()).isFalse();
+        assertThat(response.getIsCovered()).isEqualTo(CoverageStatus.NOT_COVERED);
         assertThat(response.getRefundAmount()).isZero();
         assertThat(response.getDeductibleAmount()).isEqualTo(100000);
+        assertThat(response.getDeductibleBasis()).isEqualTo("보장 제외로 진료비 전액 자기부담");
     }
 
     private CoverageRule createCoverageRule(
@@ -116,14 +146,36 @@ class CalculationServiceTest {
         );
     }
 
-    private CalculationRequest createCalculationRequest(Integer medicalCost) {
+    private Long saveUserInsurance() {
+        Insurance insurance = insuranceRepository.save(Insurance.builder()
+                .companyName("삼성화재")
+                .productName("테스트 실손보험")
+                .contractType(ContractType.INDIVIDUAL)
+                .generation(4)
+                .coverageStructure(CoverageStructure.THREE_UNCOVERED)
+                .cautionPoint(CautionPoint.RENEWAL_TYPE)
+                .build());
+
+        UserInsurance userInsurance = userInsuranceRepository.save(UserInsurance.builder()
+                .userId(TEST_USER_ID)
+                .insurance(insurance)
+                .subscribedAt("2025-04")
+                .hasNonCoveredRider(true)
+                .build());
+
+        return userInsurance.getId();
+    }
+
+    private CalculationRequest createCalculationRequest(Long userInsuranceId, Integer medicalCost) {
         CalculationRequest request = new CalculationRequest();
-        ReflectionTestUtils.setField(request, "insuranceId", TEST_INSURANCE_ID);
+        ReflectionTestUtils.setField(request, "insuranceId", "ins_" + userInsuranceId);
         ReflectionTestUtils.setField(request, "medicalCost", medicalCost);
         ReflectionTestUtils.setField(request, "visitType", VisitType.OUTPATIENT);
         ReflectionTestUtils.setField(request, "treatmentCategory", TreatmentCategory.CT);
         ReflectionTestUtils.setField(request, "purposeType", PurposeType.UNKNOWN);
         ReflectionTestUtils.setField(request, "ediCode", null);
+        ReflectionTestUtils.setField(request, "hospitalType", HospitalType.UNKNOWN);
+        ReflectionTestUtils.setField(request, "payType", PayType.UNKNOWN);
         return request;
     }
 }

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleGeneratorTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleGeneratorTest.java
@@ -66,7 +66,7 @@ class CoverageRuleGeneratorTest {
         );
 
         assertThat(coverageRule.getEdiCode()).isEqualTo("EDI002");
-        assertThat(coverageRule.getTreatmentCategory()).isEqualTo(TreatmentCategory.MANUAL_THERAPY);
+        assertThat(coverageRule.getTreatmentCategory()).isEqualTo(TreatmentCategory.CHIROPRACTIC);
         assertThat(coverageRule.getCoverageRate()).isEqualTo(70);
         assertThat(coverageRule.getDeductibleAmount()).isEqualTo(30000);
         assertThat(coverageRule.getLimitAmount()).isEqualTo(100000);
@@ -84,7 +84,7 @@ class CoverageRuleGeneratorTest {
         );
 
         assertThat(coverageRule.getVisitType()).isEqualTo(VisitType.MEDICATION);
-        assertThat(coverageRule.getTreatmentCategory()).isEqualTo(TreatmentCategory.GENERAL_TREATMENT);
+        assertThat(coverageRule.getTreatmentCategory()).isEqualTo(TreatmentCategory.GENERAL);
     }
 
     @Test

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleResolverTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleResolverTest.java
@@ -111,7 +111,7 @@ class CoverageRuleResolverTest {
 
     @ParameterizedTest
     @CsvSource({
-            "FIRST, 100, 0",
+            "FIRST, 90, 10000",
             "SECOND, 80, 20000",
             "THIRD, 70, 30000",
             "FOURTH, 70, 30000"


### PR DESCRIPTION
### 💻 작업 내용
- 환급금 계산 API 요청/응답 DTO를 신규 명세에 맞게 변경
- 보험 정보 기반으로 상품명, 보험사명, 가입일, 보험 정보 등을 응답에 포함
- 진료 항목/목적 enum을 신규 요청값 기준으로 정리
- EDI 없는 fallback CoverageRule seed를 변경된 enum 기준으로 수정
- 계산 API 및 CoverageRule 관련 테스트 반영

### ✨ 리뷰 포인트
- 계산 응답 필드 구성이 프론트 명세와 맞는지 확인 부탁드립니다.
- EDI 없는 fallback 룰의 보장률/자기부담금 기준이 적절한지 봐주세요.

### 📝 메모
- 전체 테스트 중 PDF/AI 분석 관련 기존 테스트는 로컬 파일/외부 설정 이슈로 실패할 수 있습니다.
- 계산 관련 테스트는 통과 확인했습니다.

### 🎯 관련 이슈
closed #67
