### PR TITLE
fix(calculation): 프론트 계산 이력 및 보장 룰 연동 정합성 수정

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationFavoriteController.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationFavoriteController.java
@@ -25,7 +25,7 @@ public class CalculationFavoriteController {
     /**
      * 계산 이력 즐겨찾기 목록 조회
      */
-    @GetMapping("/favorites")
+    @GetMapping({"/favorites", "/save"})
     public ApiResponse<List<CalculationFavoriteResponse>> getFavorites(
             @AuthenticationPrincipal CustomUserDetails userDetails
     ) {

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/dto/CalculationFavoriteResponse.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/dto/CalculationFavoriteResponse.java
@@ -1,31 +1,55 @@
 package com.silsonfit.silsonfit_api.domain.calculation.dto;
 
 import com.silsonfit.silsonfit_api.domain.calculation.entity.CalculationHistory;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceInfoDto;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
+import java.util.List;
 
 /**
  * 계산 이력 즐겨찾기 응답
  */
 public record CalculationFavoriteResponse(
-        String id,
+        Long id,
+        String calculationHistoryId,
         OffsetDateTime calculatedDate,
         String insuranceCoverage,
+        List<String> basis,
+        String insuranceId,
+        String productName,
+        String companyName,
+        String generation,
+        String joinDate,
+        String ediCode,
         Integer medicalCost,
         Integer refundAmount,
         Boolean isCovered,
-        Boolean isFavorite
+        Boolean isFavorite,
+        Boolean isSaved
 ) {
 
     public static CalculationFavoriteResponse from(CalculationHistory history) {
+        return from(history, null);
+    }
+
+    public static CalculationFavoriteResponse from(CalculationHistory history, InsuranceInfoDto insuranceInfo) {
         return new CalculationFavoriteResponse(
-                "calc_" + history.getId(),
+                history.getId(),
+                String.valueOf(history.getId()),
                 history.getCreatedAt().atOffset(ZoneOffset.UTC),
                 history.getTreatmentCategory().getDescription(),
+                List.of(history.getTreatmentCategory().getDescription()),
+                String.valueOf(history.getInsuranceId()),
+                insuranceInfo != null ? insuranceInfo.productName() : null,
+                insuranceInfo != null ? insuranceInfo.companyName() : null,
+                insuranceInfo != null ? String.valueOf(insuranceInfo.generation()) : null,
+                insuranceInfo != null ? insuranceInfo.subscribedAt() : null,
+                history.getEdiCode(),
                 history.getMedicalCost(),
                 history.getRefundAmount(),
                 history.getIsCovered(),
+                history.getIsFavorite(),
                 history.getIsFavorite()
         );
     }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/dto/CalculationHistoryListResponse.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/dto/CalculationHistoryListResponse.java
@@ -1,11 +1,14 @@
 package com.silsonfit.silsonfit_api.domain.calculation.dto;
 
+import com.fasterxml.jackson.annotation.JsonProperty;
 import com.silsonfit.silsonfit_api.domain.calculation.entity.CalculationHistory;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceInfoDto;
 import org.springframework.data.domain.Page;
 
 import java.time.OffsetDateTime;
 import java.time.ZoneOffset;
 import java.util.List;
+import java.util.function.Function;
 
 /**
  * 계산 이력 목록 응답
@@ -24,23 +27,62 @@ public record CalculationHistoryListResponse(
         );
     }
 
+    public static CalculationHistoryListResponse from(
+            Page<CalculationHistory> histories,
+            Function<Long, InsuranceInfoDto> insuranceInfoResolver
+    ) {
+        return new CalculationHistoryListResponse(
+                histories.getContent().stream()
+                        .map(history -> CalculationSummary.from(history, insuranceInfoResolver.apply(history.getInsuranceId())))
+                        .toList(),
+                PageInfo.from(histories)
+        );
+    }
+
+    @JsonProperty("content")
+    public List<CalculationSummary> content() {
+        return calculations;
+    }
+
     public record CalculationSummary(
-            String id,
+            Long id,
+            String calculationHistoryId,
             OffsetDateTime calculatedDate,
             String insuranceCoverage,
+            List<String> basis,
+            String insuranceId,
+            String productName,
+            String companyName,
+            String generation,
+            String joinDate,
+            String ediCode,
             Integer medicalCost,
             Integer refundAmount,
-            Boolean isCovered
+            Boolean isCovered,
+            Boolean isSaved
     ) {
 
         public static CalculationSummary from(CalculationHistory history) {
+            return from(history, null);
+        }
+
+        public static CalculationSummary from(CalculationHistory history, InsuranceInfoDto insuranceInfo) {
             return new CalculationSummary(
-                    "calc_" + history.getId(),
+                    history.getId(),
+                    String.valueOf(history.getId()),
                     history.getCreatedAt().atOffset(ZoneOffset.UTC),
                     history.getTreatmentCategory().getDescription(),
+                    List.of(history.getTreatmentCategory().getDescription()),
+                    String.valueOf(history.getInsuranceId()),
+                    insuranceInfo != null ? insuranceInfo.productName() : null,
+                    insuranceInfo != null ? insuranceInfo.companyName() : null,
+                    insuranceInfo != null ? String.valueOf(insuranceInfo.generation()) : null,
+                    insuranceInfo != null ? insuranceInfo.subscribedAt() : null,
+                    history.getEdiCode(),
                     history.getMedicalCost(),
                     history.getRefundAmount(),
-                    history.getIsCovered()
+                    history.getIsCovered(),
+                    history.getIsFavorite()
             );
         }
     }

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/TreatmentCategory.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/enums/TreatmentCategory.java
@@ -14,7 +14,7 @@ public enum TreatmentCategory {
     MRI("MRI"),
     CT("CT"),
     CHIROPRACTIC("도수치료"),
-    EMERGENCY("응급"),
+    SHOCKWAVE_THERAPY("체외충격파"),
     INJECTION("주사"),
     PHYSICAL_THERAPY("물리치료");
 

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/repository/CoverageRuleRepository.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/repository/CoverageRuleRepository.java
@@ -7,6 +7,7 @@ import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.VisitType;
 import org.springframework.data.jpa.repository.JpaRepository;
 
+import java.util.List;
 import java.util.Optional;
 
 /**
@@ -24,9 +25,29 @@ public interface CoverageRuleRepository extends JpaRepository<CoverageRule, Long
     );
 
     /**
+     * 보험 ID + EDI 코드 기반 보장 룰 조회
+     *
+     * 중복 데이터가 있더라도 최신 룰 하나만 사용한다.
+     */
+    Optional<CoverageRule> findFirstByInsuranceIdAndEdiCodeOrderByIdDesc(
+            Long insuranceId,
+            String ediCode
+    );
+
+    /**
      * 보험 세대 + 진료 유형/항목/목적 기반 fallback 보장 룰 조회
      */
     Optional<CoverageRule> findByGenerationAndVisitTypeAndTreatmentCategoryAndPurposeType(
+            InsuranceGeneration generation,
+            VisitType visitType,
+            TreatmentCategory treatmentCategory,
+            PurposeType purposeType
+    );
+
+    /**
+     * 보험/EDI 전용 룰이 아닌 세대 fallback 보장 룰 조회
+     */
+    List<CoverageRule> findByInsuranceIdIsNullAndEdiCodeIsNullAndGenerationAndVisitTypeAndTreatmentCategoryAndPurposeTypeOrderByIdAsc(
             InsuranceGeneration generation,
             VisitType visitType,
             TreatmentCategory treatmentCategory,

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationFavoriteService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationFavoriteService.java
@@ -3,6 +3,8 @@ package com.silsonfit.silsonfit_api.domain.calculation.service;
 import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationFavoriteResponse;
 import com.silsonfit.silsonfit_api.domain.calculation.entity.CalculationHistory;
 import com.silsonfit.silsonfit_api.domain.calculation.repository.CalculationHistoryRepository;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceInfoDto;
+import com.silsonfit.silsonfit_api.domain.insurance.service.InsuranceService;
 import com.silsonfit.silsonfit_api.global.error.BusinessException;
 import com.silsonfit.silsonfit_api.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
@@ -22,14 +24,24 @@ import java.util.List;
 public class CalculationFavoriteService {
 
     private final CalculationHistoryRepository calculationHistoryRepository;
+    private final InsuranceService insuranceService;
 
     /**
      * 계산 이력 즐겨찾기 목록 조회
      */
     public List<CalculationFavoriteResponse> getFavorites(Long userId) {
         return calculationHistoryRepository.findFavoritesByUserId(userId).stream()
-                .map(CalculationFavoriteResponse::from)
+                .map(history -> CalculationFavoriteResponse.from(history, resolveInsuranceInfo(history.getInsuranceId())))
                 .toList();
+    }
+
+    private InsuranceInfoDto resolveInsuranceInfo(Long userInsuranceId) {
+        try {
+            return insuranceService.getInsuranceInfo(userInsuranceId);
+        } catch (BusinessException e) {
+            log.warn("계산 즐겨찾기 이력의 보험 정보를 찾을 수 없습니다. - userInsuranceId={}", userInsuranceId);
+            return null;
+        }
     }
 
     /**

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationHistoryService.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationHistoryService.java
@@ -3,10 +3,13 @@ package com.silsonfit.silsonfit_api.domain.calculation.service;
 import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationHistoryListResponse;
 import com.silsonfit.silsonfit_api.domain.calculation.entity.CalculationHistory;
 import com.silsonfit.silsonfit_api.domain.calculation.repository.CalculationHistoryRepository;
+import com.silsonfit.silsonfit_api.domain.insurance.dto.InsuranceInfoDto;
+import com.silsonfit.silsonfit_api.domain.insurance.service.InsuranceService;
 import com.silsonfit.silsonfit_api.global.error.BusinessException;
 import com.silsonfit.silsonfit_api.global.error.ErrorCode;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.domain.PageRequest;
 import org.springframework.data.domain.Pageable;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
@@ -21,14 +24,27 @@ import org.springframework.transaction.annotation.Transactional;
 public class CalculationHistoryService {
 
     private final CalculationHistoryRepository calculationHistoryRepository;
+    private final InsuranceService insuranceService;
 
     /**
      * 사용자별 계산 이력 목록 조회
      */
     public CalculationHistoryListResponse getHistories(Long userId, Pageable pageable) {
+        Pageable fixedSortPageable = PageRequest.of(pageable.getPageNumber(), pageable.getPageSize());
+
         return CalculationHistoryListResponse.from(
-                calculationHistoryRepository.findByUserIdAndIsDeletedFalseOrderByCreatedAtDescIdDesc(userId, pageable)
+                calculationHistoryRepository.findByUserIdAndIsDeletedFalseOrderByCreatedAtDescIdDesc(userId, fixedSortPageable),
+                this::resolveInsuranceInfo
         );
+    }
+
+    private InsuranceInfoDto resolveInsuranceInfo(Long userInsuranceId) {
+        try {
+            return insuranceService.getInsuranceInfo(userInsuranceId);
+        } catch (BusinessException e) {
+            log.warn("계산 이력의 보험 정보를 찾을 수 없습니다. - userInsuranceId={}", userInsuranceId);
+            return null;
+        }
     }
 
     /**

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleGenerator.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleGenerator.java
@@ -81,7 +81,7 @@ public class CoverageRuleGenerator {
             return TreatmentCategory.CHIROPRACTIC;
         }
         if (ediCode.containsKeyword("충격파")) {
-            return TreatmentCategory.PHYSICAL_THERAPY;
+            return TreatmentCategory.SHOCKWAVE_THERAPY;
         }
         if (ediCode.containsKeyword("주사")) {
             return TreatmentCategory.INJECTION;

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleResolver.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/domain/calculation/service/CoverageRuleResolver.java
@@ -9,10 +9,14 @@ import com.silsonfit.silsonfit_api.domain.calculation.repository.CoverageRuleRep
 import com.silsonfit.silsonfit_api.domain.calculation.vo.CoverageRuleContext;
 import com.silsonfit.silsonfit_api.global.error.BusinessException;
 import com.silsonfit.silsonfit_api.global.error.ErrorCode;
+import lombok.extern.slf4j.Slf4j;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
+
+import java.util.List;
+import java.util.Optional;
 
 /**
  * 보장 룰 조회 Resolver
@@ -22,6 +26,7 @@ import org.springframework.util.StringUtils;
  * - EDI 코드가 없으면 보험 세대 + 진료 유형/항목/목적 기반 룰로 대체 조회한다.
  */
 @Service
+@Slf4j
 @RequiredArgsConstructor
 @Transactional
 public class CoverageRuleResolver {
@@ -50,7 +55,7 @@ public class CoverageRuleResolver {
         if (StringUtils.hasText(ediCode)) {
             String normalizedEdiCode = ediCode.trim();
 
-            return coverageRuleRepository.findByInsuranceIdAndEdiCode(context.insuranceId(), normalizedEdiCode)
+            return coverageRuleRepository.findFirstByInsuranceIdAndEdiCodeOrderByIdDesc(context.insuranceId(), normalizedEdiCode)
                     .orElseGet(() -> generateAndSaveByEdiCode(context, normalizedEdiCode));
         }
 
@@ -84,12 +89,38 @@ public class CoverageRuleResolver {
             TreatmentCategory treatmentCategory,
             PurposeType purposeType
     ) {
-        return coverageRuleRepository.findByGenerationAndVisitTypeAndTreatmentCategoryAndPurposeType(
-                        context.generation(),
-                        visitType,
-                        treatmentCategory,
-                        purposeType
-                )
+        return findRule(context, visitType, treatmentCategory, purposeType)
+                .or(() -> findRule(context, visitType, TreatmentCategory.GENERAL, purposeType))
+                .or(() -> findRule(context, VisitType.OUTPATIENT, treatmentCategory, purposeType))
+                .or(() -> findRule(context, VisitType.OUTPATIENT, TreatmentCategory.GENERAL, purposeType))
+                .or(() -> findRule(context, VisitType.OUTPATIENT, TreatmentCategory.GENERAL, PurposeType.TREATMENT))
                 .orElseThrow(() -> new BusinessException(ErrorCode.COVERAGE_RULE_NOT_FOUND));
+    }
+
+    private Optional<CoverageRule> findRule(
+            CoverageRuleContext context,
+            VisitType visitType,
+            TreatmentCategory treatmentCategory,
+            PurposeType purposeType
+    ) {
+        List<CoverageRule> rules = coverageRuleRepository.findByInsuranceIdIsNullAndEdiCodeIsNullAndGenerationAndVisitTypeAndTreatmentCategoryAndPurposeTypeOrderByIdAsc(
+                context.generation(),
+                visitType,
+                treatmentCategory,
+                purposeType
+        );
+
+        if (rules.size() > 1) {
+            log.warn(
+                    "중복 fallback 보장 룰이 존재합니다. 첫 번째 룰을 사용합니다. generation={}, visitType={}, treatmentCategory={}, purposeType={}, count={}",
+                    context.generation(),
+                    visitType,
+                    treatmentCategory,
+                    purposeType,
+                    rules.size()
+            );
+        }
+
+        return rules.stream().findFirst();
     }
 }

--- a/silsonfit-api/src/main/resources/data.sql
+++ b/silsonfit-api/src/main/resources/data.sql
@@ -79,7 +79,7 @@ insert into coverage_rule (
  '["3세대 실손 도수치료 비급여 특약 보장 추정","3대 비급여 특약 항목은 높은 자기부담 기준 fallback 적용"]',
  '도수치료 특약 미가입, 횟수 제한 초과, 의학적 필요성 부족 시 보장되지 않을 수 있습니다.'
 ),
-(null, 'THIRD', null, 'OUTPATIENT', 'PHYSICAL_THERAPY', 'TREATMENT',
+(null, 'THIRD', null, 'OUTPATIENT', 'SHOCKWAVE_THERAPY', 'TREATMENT',
  true, 70, 30000, null,
  '["3세대 실손 체외충격파 비급여 특약 보장 추정","3대 비급여 특약 항목은 높은 자기부담 기준 fallback 적용"]',
  '체외충격파 특약 미가입, 횟수 제한 초과, 의학적 필요성 부족 시 보장되지 않을 수 있습니다.'
@@ -111,7 +111,7 @@ insert into coverage_rule (
  '["4세대 실손 도수치료 비급여 보장 추정","비급여 항목은 높은 자기부담 기준 fallback 적용"]',
  '도수치료는 횟수 제한, 증상 개선 여부, 의학적 필요성에 따라 보장 여부가 달라질 수 있습니다.'
 ),
-(null, 'FOURTH', null, 'OUTPATIENT', 'PHYSICAL_THERAPY', 'TREATMENT',
+(null, 'FOURTH', null, 'OUTPATIENT', 'SHOCKWAVE_THERAPY', 'TREATMENT',
  true, 70, 30000, null,
  '["4세대 실손 체외충격파 비급여 보장 추정","비급여 항목은 높은 자기부담 기준 fallback 적용"]',
  '체외충격파 치료는 횟수 제한, 의학적 필요성에 따라 보장 여부가 달라질 수 있습니다.'

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationFavoriteControllerTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationFavoriteControllerTest.java
@@ -50,11 +50,20 @@ class CalculationFavoriteControllerTest {
     void getFavorites_success() throws Exception {
         when(calculationFavoriteService.getFavorites(10L)).thenReturn(List.of(
                 new CalculationFavoriteResponse(
-                        "calc_1",
+                        1L,
+                        "1",
                         OffsetDateTime.parse("2026-05-04T10:00:00Z"),
                         "MRI",
+                        List.of("MRI"),
+                        "1",
+                        "테스트 보험",
+                        "테스트 보험사",
+                        "4",
+                        "2026-05",
+                        null,
                         100000,
                         70000,
+                        true,
                         true,
                         true
                 )
@@ -65,13 +74,17 @@ class CalculationFavoriteControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.data[0].id").value("calc_1"))
+                .andExpect(jsonPath("$.data[0].id").value(1))
+                .andExpect(jsonPath("$.data[0].calculationHistoryId").value("1"))
                 .andExpect(jsonPath("$.data[0].calculatedDate").value("2026-05-04T10:00:00Z"))
                 .andExpect(jsonPath("$.data[0].insuranceCoverage").value("MRI"))
+                .andExpect(jsonPath("$.data[0].basis[0]").value("MRI"))
+                .andExpect(jsonPath("$.data[0].productName").value("테스트 보험"))
                 .andExpect(jsonPath("$.data[0].medicalCost").value(100000))
                 .andExpect(jsonPath("$.data[0].refundAmount").value(70000))
                 .andExpect(jsonPath("$.data[0].isCovered").value(true))
-                .andExpect(jsonPath("$.data[0].isFavorite").value(true));
+                .andExpect(jsonPath("$.data[0].isFavorite").value(true))
+                .andExpect(jsonPath("$.data[0].isSaved").value(true));
     }
 
 }

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationHistoryControllerTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/controller/CalculationHistoryControllerTest.java
@@ -38,12 +38,21 @@ class CalculationHistoryControllerTest {
     void getHistories_success() throws Exception {
         CalculationHistoryListResponse response = new CalculationHistoryListResponse(
                 List.of(new CalculationHistoryListResponse.CalculationSummary(
-                        "calc_123",
+                        123L,
+                        "123",
                         OffsetDateTime.parse("2024-06-01T10:00:00Z"),
                         "MRI",
+                        List.of("MRI"),
+                        "1",
+                        "테스트 보험",
+                        "테스트 보험사",
+                        "4",
+                        "2026-05",
+                        null,
                         3000000,
                         2500000,
-                        true
+                        true,
+                        false
                 )),
                 new CalculationHistoryListResponse.PageInfo(0, 20, 3, 45)
         );
@@ -58,12 +67,17 @@ class CalculationHistoryControllerTest {
                 .andExpect(status().isOk())
                 .andExpect(jsonPath("$.code").value(200))
                 .andExpect(jsonPath("$.message").value("success"))
-                .andExpect(jsonPath("$.data.calculations[0].id").value("calc_123"))
+                .andExpect(jsonPath("$.data.calculations[0].id").value(123))
+                .andExpect(jsonPath("$.data.calculations[0].calculationHistoryId").value("123"))
                 .andExpect(jsonPath("$.data.calculations[0].calculatedDate").value("2024-06-01T10:00:00Z"))
                 .andExpect(jsonPath("$.data.calculations[0].insuranceCoverage").value("MRI"))
+                .andExpect(jsonPath("$.data.calculations[0].basis[0]").value("MRI"))
+                .andExpect(jsonPath("$.data.calculations[0].productName").value("테스트 보험"))
+                .andExpect(jsonPath("$.data.content[0].calculationHistoryId").value("123"))
                 .andExpect(jsonPath("$.data.calculations[0].medicalCost").value(3000000))
                 .andExpect(jsonPath("$.data.calculations[0].refundAmount").value(2500000))
                 .andExpect(jsonPath("$.data.calculations[0].isCovered").value(true))
+                .andExpect(jsonPath("$.data.calculations[0].isSaved").value(false))
                 .andExpect(jsonPath("$.data.pageInfo.page").value(0))
                 .andExpect(jsonPath("$.data.pageInfo.size").value(20))
                 .andExpect(jsonPath("$.data.pageInfo.totalPages").value(3))

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationFavoriteServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationFavoriteServiceTest.java
@@ -4,6 +4,7 @@ import com.silsonfit.silsonfit_api.domain.calculation.dto.CalculationFavoriteRes
 import com.silsonfit.silsonfit_api.domain.calculation.entity.CalculationHistory;
 import com.silsonfit.silsonfit_api.domain.calculation.enums.TreatmentCategory;
 import com.silsonfit.silsonfit_api.domain.calculation.repository.CalculationHistoryRepository;
+import com.silsonfit.silsonfit_api.domain.insurance.service.InsuranceService;
 import com.silsonfit.silsonfit_api.global.error.BusinessException;
 import com.silsonfit.silsonfit_api.global.error.ErrorCode;
 import org.junit.jupiter.api.DisplayName;
@@ -27,6 +28,9 @@ class CalculationFavoriteServiceTest {
 
     @Mock
     CalculationHistoryRepository calculationHistoryRepository;
+
+    @Mock
+    InsuranceService insuranceService;
 
     @InjectMocks
     CalculationFavoriteService calculationFavoriteService;
@@ -64,12 +68,14 @@ class CalculationFavoriteServiceTest {
         List<CalculationFavoriteResponse> responses = calculationFavoriteService.getFavorites(10L);
 
         assertThat(responses).hasSize(1);
-        assertThat(responses.get(0).id()).isEqualTo("calc_1");
+        assertThat(responses.get(0).id()).isEqualTo(1L);
+        assertThat(responses.get(0).calculationHistoryId()).isEqualTo("1");
         assertThat(responses.get(0).insuranceCoverage()).isEqualTo("MRI");
         assertThat(responses.get(0).medicalCost()).isEqualTo(100000);
         assertThat(responses.get(0).refundAmount()).isEqualTo(70000);
         assertThat(responses.get(0).isCovered()).isTrue();
         assertThat(responses.get(0).isFavorite()).isTrue();
+        assertThat(responses.get(0).isSaved()).isTrue();
     }
 
     @Test

--- a/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationHistoryServiceTest.java
+++ b/silsonfit-api/src/test/java/com/silsonfit/silsonfit_api/domain/calculation/service/CalculationHistoryServiceTest.java
@@ -64,16 +64,18 @@ class CalculationHistoryServiceTest {
         );
 
         assertThat(response.calculations()).hasSize(2);
-        assertThat(response.calculations().get(0).id()).isEqualTo("calc_" + secondHistory.getId());
+        assertThat(response.calculations().get(0).id()).isEqualTo(secondHistory.getId());
+        assertThat(response.calculations().get(0).calculationHistoryId()).isEqualTo(String.valueOf(secondHistory.getId()));
         assertThat(response.calculations().get(0).insuranceCoverage()).isEqualTo("일반진료");
         assertThat(response.calculations().get(0).medicalCost()).isEqualTo(100000);
         assertThat(response.calculations().get(0).refundAmount()).isEqualTo(70000);
         assertThat(response.calculations().get(0).isCovered()).isTrue();
-        assertThat(response.calculations().get(1).id()).isEqualTo("calc_" + firstHistory.getId());
+        assertThat(response.calculations().get(0).isSaved()).isFalse();
+        assertThat(response.calculations().get(1).id()).isEqualTo(firstHistory.getId());
         assertThat(response.calculations())
-                .noneSatisfy(calculation -> assertThat(calculation.id()).isEqualTo("calc_" + otherUserHistory.getId()));
+                .noneSatisfy(calculation -> assertThat(calculation.id()).isEqualTo(otherUserHistory.getId()));
         assertThat(response.calculations())
-                .noneSatisfy(calculation -> assertThat(calculation.id()).isEqualTo("calc_" + deletedHistory.getId()));
+                .noneSatisfy(calculation -> assertThat(calculation.id()).isEqualTo(deletedHistory.getId()));
         assertThat(response.pageInfo().page()).isZero();
         assertThat(response.pageInfo().size()).isEqualTo(20);
         assertThat(response.pageInfo().totalElements()).isEqualTo(2);


### PR DESCRIPTION
### 💻 작업 내용
- 프론트 연동을 위해 계산 이력 응답 필드 확장
- `/api/calculations/save` 경로 추가
- `SHOCKWAVE_THERAPY` 진료 항목 지원
- 중복 fallback 보장 룰 조회 시 500 발생하지 않도록 방어 처리
- 계산 이력/즐겨찾기/보장 룰 관련 테스트 수정

### ✨ 리뷰 포인트
- 계산 이력 응답 DTO에 프론트 표시용 필드를 추가한 방향이 적절한지 확인 부탁드립니다.
- 중복 fallback 룰이 있을 때 첫 번째 룰을 사용하는 정책이 괜찮은지 봐주세요.

### 📝 메모
- FE `develop` 기준 연동 중 발견된 이슈를 BE에서 호환되도록 수정했습니다.
- 전체 테스트 중 AI/PDF 관련 테스트는 로컬 리소스/환경 이슈로 별도 확인이 필요합니다.
- 계산/히스토리 관련 테스트는 통과 확인했습니다.

### 🎯 관련 이슈
closed #70 