### PR TITLE
refactor: CORS 허용 origin 설정 외부화

### DIFF
--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/CorsProperties.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/CorsProperties.java
@@ -1,0 +1,11 @@
+package com.silsonfit.silsonfit_api.global.config;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+import java.util.List;
+
+@ConfigurationProperties(prefix = "app.cors")
+public record CorsProperties(
+        List<String> allowedOrigins
+) {
+}

--- a/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/SecurityConfig.java
+++ b/silsonfit-api/src/main/java/com/silsonfit/silsonfit_api/global/config/SecurityConfig.java
@@ -3,6 +3,7 @@ package com.silsonfit.silsonfit_api.global.config;
 import com.silsonfit.silsonfit_api.global.auth.JwtAuthenticationFilter;
 import com.silsonfit.silsonfit_api.global.auth.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
@@ -17,12 +18,15 @@ import org.springframework.web.cors.CorsConfigurationSource;
 import org.springframework.web.cors.UrlBasedCorsConfigurationSource;
 
 import java.util.Arrays;
+import java.util.List;
 
 @Configuration
 @RequiredArgsConstructor
+@EnableConfigurationProperties(CorsProperties.class)
 public class SecurityConfig {
 
     private final JwtTokenProvider jwtTokenProvider;
+    private final CorsProperties corsProperties;
 
     @Bean
     public SecurityFilterChain securityFilterChain(HttpSecurity http) throws Exception {
@@ -88,13 +92,7 @@ public class SecurityConfig {
     public CorsConfigurationSource corsConfigurationSource() {
         CorsConfiguration configuration = new CorsConfiguration();
 
-        // 허용할 Origin (프론트엔드 주소)
-        configuration.setAllowedOrigins(Arrays.asList(
-                "http://localhost:5173",
-                "http://localhost:5174",
-                "http://127.0.0.1:5173",
-                "http://127.0.0.1:5174"
-        ));
+        configuration.setAllowedOrigins(resolveAllowedOrigins());
 
         // 허용할 HTTP 메서드
         configuration.setAllowedMethods(Arrays.asList("GET", "POST", "PUT", "DELETE", "PATCH", "OPTIONS"));
@@ -113,5 +111,16 @@ public class SecurityConfig {
         source.registerCorsConfiguration("/**", configuration);
 
         return source;
+    }
+
+    private List<String> resolveAllowedOrigins() {
+        if (corsProperties.allowedOrigins() == null) {
+            return List.of();
+        }
+
+        return corsProperties.allowedOrigins().stream()
+                .map(String::trim)
+                .filter(origin -> !origin.isBlank())
+                .toList();
     }
 }

--- a/silsonfit-api/src/main/resources/application-dev.yml
+++ b/silsonfit-api/src/main/resources/application-dev.yml
@@ -55,6 +55,14 @@ management:
     health:
       show-details: always
 
+app:
+  cors:
+    allowed-origins:
+      - http://localhost:5173
+      - http://localhost:5174
+      - http://127.0.0.1:5173
+      - http://127.0.0.1:5174
+
 logging:
   level:
     org.hibernate.SQL: DEBUG

--- a/silsonfit-api/src/main/resources/application-prod.yml
+++ b/silsonfit-api/src/main/resources/application-prod.yml
@@ -41,6 +41,10 @@ management:
     health:
       show-details: never
 
+app:
+  cors:
+    allowed-origins: ${CORS_ALLOWED_ORIGINS:}
+
 logging:
   level:
     org.hibernate.SQL: INFO


### PR DESCRIPTION
### 💻 작업 내용

* CORS 허용 Origin 하드코딩 제거
* application.yml 기반으로 허용 Origin 외부 설정화

### ✨ 리뷰 포인트

* 환경별(dev/prod) CORS 설정 분리 방식 위주로 확인 부탁드립니다.

### 📝 메모

* 운영 환경 도메인 추가 시 코드 수정 없이 설정만 변경 가능하도록 개선했습니다.
* prod에서는 "CORS_ALLOWED_ORIGINS=https://example.com,https://www.example.com" 와 같이 추가하면 됩니다.
